### PR TITLE
Fix WebMCP package documentation based on actual implementation

### DIFF
--- a/packages/extension-tools.mdx
+++ b/packages/extension-tools.mdx
@@ -1,13 +1,13 @@
 ---
 title: "@mcp-b/extension-tools"
-description: "MCP tools for Chrome Extension APIs with auto-generated bindings"
+description: "MCP wrappers for Chrome Extension APIs enabling protocol-based browser control"
 sidebarTitle: "Extension Tools"
 icon: "puzzle-piece"
 ---
 
 ## Overview
 
-The `@mcp-b/extension-tools` package provides auto-generated MCP tools for interacting with Chrome Extension APIs. It enables AI agents to control browser functionality through the Model Context Protocol.
+The `@mcp-b/extension-tools` package provides Model Context Protocol (MCP) wrappers for Chrome Extension APIs. It enables standardized, protocol-based access to browser extension functionalities, allowing MCP clients to interact with Chrome's extensive API surface.
 
 ## Installation
 
@@ -17,477 +17,403 @@ npm install @mcp-b/extension-tools
 
 ## Key Features
 
-- Auto-generated bindings for Chrome Extension APIs
-- Full TypeScript support
-- Permission-aware tool exposure
-- Secure sandboxed execution
-- Compatible with Manifest V3
+- MCP wrappers for 62+ Chrome Extension APIs
+- Full TypeScript support with comprehensive type definitions
+- Zod-based input validation and schema generation
+- Structured error handling and response formatting
+- Compatible with Manifest V3 extensions
+
+## Architecture
+
+The package wraps Chrome Extension APIs into MCP-compatible tools, enabling remote procedure calls through the MCP protocol. Each Chrome API is wrapped in its own tools class that extends `BaseApiTools`.
 
 ## Basic Usage
 
-### Setting up Extension Tools
+### Setting Up in Background Script
 
 ```typescript
-import { ExtensionTools } from '@mcp-b/extension-tools';
-import { McpServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { TabServerTransport } from '@mcp-b/transports';
+import { 
+  TabsApiTools,
+  StorageApiTools,
+  BookmarksApiTools 
+} from '@mcp-b/extension-tools';
 
-// Initialize extension tools
-const extensionTools = new ExtensionTools({
-  permissions: ['tabs', 'storage', 'bookmarks']
-});
-
-// Register with MCP server
+// Create MCP server
 const server = new McpServer({
   name: 'chrome-extension-server',
   version: '1.0.0'
 });
 
-// Add tools to server
-extensionTools.registerTools(server);
+// Register Chrome API tools
+const tabsTools = new TabsApiTools(server, {
+  createTab: true,
+  updateTab: true,
+  removeTabs: true,
+  queryTabs: true
+});
+tabsTools.register();
+
+const storageTools = new StorageApiTools(server, {
+  getStorageData: true,
+  setStorageData: true,
+  removeStorageData: true
+});
+storageTools.register();
+
+// Set up transport
+const transport = new TabServerTransport({
+  allowedOrigins: ['*']
+});
+
+// Connect server to transport
+await server.connect(transport);
 ```
 
-### Using in Content Scripts
+### Client-Side Usage
 
 ```typescript
-// content-script.ts
-import { createExtensionBridge } from '@mcp-b/extension-tools';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { TabClientTransport } from '@mcp-b/transports';
 
-const bridge = createExtensionBridge();
-
-// Expose tools to the page
-bridge.exposeTools([
-  'tabs.query',
-  'tabs.create',
-  'storage.local.get',
-  'storage.local.set'
-]);
-
-// Listen for tool calls from the page
-bridge.onToolCall(async (tool, params) => {
-  console.log(`Tool called: ${tool}`, params);
-  // Tool execution is handled automatically
-});
-```
-
-## Available Tools
-
-### Tabs API
-
-```typescript
-// Query tabs
-const tabs = await callTool('tabs.query', {
-  active: true,
-  currentWindow: true
+const transport = new TabClientTransport({
+  targetOrigin: window.location.origin
 });
 
-// Create new tab
-const newTab = await callTool('tabs.create', {
-  url: 'https://example.com',
-  active: true
+const client = new Client({
+  name: 'web-client',
+  version: '1.0.0'
+}, {
+  capabilities: {}
 });
 
-// Update tab
-await callTool('tabs.update', {
-  tabId: tabs[0].id,
-  url: 'https://newurl.com'
-});
+await client.connect(transport);
 
-// Close tabs
-await callTool('tabs.remove', {
-  tabIds: [tab.id]
-});
-```
-
-### Storage API
-
-```typescript
-// Store data
-await callTool('storage.local.set', {
-  key: 'user_preferences',
-  value: { theme: 'dark', language: 'en' }
-});
-
-// Retrieve data
-const data = await callTool('storage.local.get', {
-  keys: ['user_preferences']
-});
-
-// Clear storage
-await callTool('storage.local.clear');
-```
-
-### Bookmarks API
-
-```typescript
-// Create bookmark
-const bookmark = await callTool('bookmarks.create', {
-  title: 'My Site',
-  url: 'https://example.com',
-  parentId: '1' // Bookmarks bar
-});
-
-// Search bookmarks
-const results = await callTool('bookmarks.search', {
-  query: 'example'
-});
-
-// Get bookmark tree
-const tree = await callTool('bookmarks.getTree');
-```
-
-### History API
-
-```typescript
-// Search history
-const historyItems = await callTool('history.search', {
-  text: 'example',
-  maxResults: 100
-});
-
-// Add URL to history
-await callTool('history.addUrl', {
-  url: 'https://example.com'
-});
-
-// Delete URL from history
-await callTool('history.deleteUrl', {
-  url: 'https://example.com'
-});
-```
-
-### Runtime API
-
-```typescript
-// Send message
-await callTool('runtime.sendMessage', {
-  message: { action: 'getData' }
-});
-
-// Get extension info
-const info = await callTool('runtime.getManifest');
-
-// Open options page
-await callTool('runtime.openOptionsPage');
-```
-
-## Advanced Configuration
-
-### Permission-based Tool Filtering
-
-```typescript
-const extensionTools = new ExtensionTools({
-  // Only expose tools for granted permissions
-  autoDetectPermissions: true,
-  
-  // Or manually specify
-  permissions: ['tabs', 'storage'],
-  
-  // Exclude specific tools
-  excludeTools: ['tabs.remove', 'storage.local.clear'],
-  
-  // Custom tool filter
-  toolFilter: (toolName) => {
-    return !toolName.includes('delete') && !toolName.includes('remove');
-  }
-});
-```
-
-### Custom Tool Wrappers
-
-```typescript
-import { wrapExtensionTool } from '@mcp-b/extension-tools';
-
-// Wrap a Chrome API with custom logic
-const customTabsQuery = wrapExtensionTool('tabs.query', {
-  // Pre-process parameters
-  beforeCall: (params) => {
-    console.log('Querying tabs:', params);
-    return params;
-  },
-  
-  // Post-process results
-  afterCall: (result, params) => {
-    console.log(`Found ${result.length} tabs`);
-    return result;
-  },
-  
-  // Handle errors
-  onError: (error, params) => {
-    console.error('Tab query failed:', error);
-    throw new Error('Failed to query tabs');
-  }
-});
-```
-
-## Use Cases
-
-### Browser Automation
-
-```typescript
-// Automated testing scenario
-async function runTest() {
-  // Open test page
-  const tab = await callTool('tabs.create', {
-    url: 'https://test.example.com'
-  });
-  
-  // Wait for page load
-  await callTool('tabs.onUpdated.addListener', {
-    tabId: tab.id,
-    changeInfo: { status: 'complete' }
-  });
-  
-  // Inject test script
-  await callTool('tabs.executeScript', {
-    tabId: tab.id,
-    code: 'document.querySelector("button").click()'
-  });
-  
-  // Check results
-  const results = await callTool('tabs.sendMessage', {
-    tabId: tab.id,
-    message: { action: 'getTestResults' }
-  });
-  
-  // Clean up
-  await callTool('tabs.remove', { tabIds: [tab.id] });
-  
-  return results;
-}
-```
-
-### Data Extraction
-
-```typescript
-// Extract data from multiple tabs
-async function extractData() {
-  const tabs = await callTool('tabs.query', {
-    url: '*://*.example.com/*'
-  });
-  
-  const results = await Promise.all(
-    tabs.map(tab => 
-      callTool('tabs.sendMessage', {
-        tabId: tab.id,
-        message: { action: 'extractData' }
-      })
-    )
-  );
-  
-  // Store extracted data
-  await callTool('storage.local.set', {
-    key: 'extracted_data',
-    value: results
-  });
-  
-  return results;
-}
-```
-
-### Session Management
-
-```typescript
-// Save browsing session
-async function saveSession() {
-  const tabs = await callTool('tabs.query', {
+// Call Chrome API through MCP
+const tabs = await client.callTool({
+  name: 'query_tabs',
+  arguments: {
+    active: true,
     currentWindow: true
-  });
-  
-  const session = {
-    timestamp: Date.now(),
-    tabs: tabs.map(tab => ({
-      url: tab.url,
-      title: tab.title,
-      index: tab.index
-    }))
-  };
-  
-  await callTool('storage.local.set', {
-    key: 'saved_session',
-    value: session
-  });
-  
-  return session;
-}
-
-// Restore session
-async function restoreSession() {
-  const { saved_session } = await callTool('storage.local.get', {
-    keys: ['saved_session']
-  });
-  
-  if (!saved_session) return;
-  
-  for (const tabInfo of saved_session.tabs) {
-    await callTool('tabs.create', {
-      url: tabInfo.url,
-      index: tabInfo.index
-    });
   }
+});
+
+const newTab = await client.callTool({
+  name: 'create_tab',
+  arguments: {
+    url: 'https://example.com',
+    active: true
+  }
+});
+```
+
+## Available API Wrappers
+
+### Core Browser APIs
+
+#### TabsApiTools
+```typescript
+const tabsTools = new TabsApiTools(server, {
+  createTab: true,        // chrome.tabs.create
+  updateTab: true,        // chrome.tabs.update
+  removeTabs: true,       // chrome.tabs.remove
+  queryTabs: true,        // chrome.tabs.query
+  getTab: true,           // chrome.tabs.get
+  duplicateTab: true,     // chrome.tabs.duplicate
+  highlightTabs: true,    // chrome.tabs.highlight
+  moveTabs: true          // chrome.tabs.move
+});
+```
+
+#### WindowsApiTools
+```typescript
+const windowsTools = new WindowsApiTools(server, {
+  createWindow: true,     // chrome.windows.create
+  updateWindow: true,     // chrome.windows.update
+  removeWindow: true,     // chrome.windows.remove
+  getWindow: true,        // chrome.windows.get
+  getAllWindows: true,    // chrome.windows.getAll
+  getCurrentWindow: true  // chrome.windows.getCurrent
+});
+```
+
+#### StorageApiTools
+```typescript
+const storageTools = new StorageApiTools(server, {
+  getStorageData: true,    // chrome.storage.local.get
+  setStorageData: true,    // chrome.storage.local.set
+  removeStorageData: true, // chrome.storage.local.remove
+  clearStorage: true,      // chrome.storage.local.clear
+  getBytesInUse: true      // chrome.storage.local.getBytesInUse
+});
+```
+
+### Content & Scripting APIs
+
+#### ScriptingApiTools
+```typescript
+const scriptingTools = new ScriptingApiTools(server, {
+  executeScript: true,     // chrome.scripting.executeScript
+  insertCSS: true,         // chrome.scripting.insertCSS
+  removeCSS: true,         // chrome.scripting.removeCSS
+  registerContentScripts: true,
+  unregisterContentScripts: true
+});
+```
+
+### Data Management APIs
+
+#### BookmarksApiTools
+```typescript
+const bookmarksTools = new BookmarksApiTools(server, {
+  createBookmark: true,    // chrome.bookmarks.create
+  removeBookmark: true,    // chrome.bookmarks.remove
+  updateBookmark: true,    // chrome.bookmarks.update
+  searchBookmarks: true,   // chrome.bookmarks.search
+  getBookmarkTree: true    // chrome.bookmarks.getTree
+});
+```
+
+#### HistoryApiTools
+```typescript
+const historyTools = new HistoryApiTools(server, {
+  searchHistory: true,     // chrome.history.search
+  addUrl: true,            // chrome.history.addUrl
+  deleteUrl: true,         // chrome.history.deleteUrl
+  deleteRange: true,       // chrome.history.deleteRange
+  deleteAll: true          // chrome.history.deleteAll
+});
+```
+
+#### DownloadsApiTools
+```typescript
+const downloadsTools = new DownloadsApiTools(server, {
+  download: true,          // chrome.downloads.download
+  pauseDownload: true,     // chrome.downloads.pause
+  resumeDownload: true,    // chrome.downloads.resume
+  cancelDownload: true,    // chrome.downloads.cancel
+  searchDownloads: true    // chrome.downloads.search
+});
+```
+
+### System APIs
+
+#### SystemApiTools
+```typescript
+// CPU information
+const cpuTools = new SystemCpuApiTools(server, {
+  getCpuInfo: true         // chrome.system.cpu.getInfo
+});
+
+// Memory information
+const memoryTools = new SystemMemoryApiTools(server, {
+  getMemoryInfo: true      // chrome.system.memory.getInfo
+});
+
+// Display information
+const displayTools = new SystemDisplayApiTools(server, {
+  getDisplayInfo: true,    // chrome.system.display.getInfo
+  getDisplayLayout: true   // chrome.system.display.getDisplayLayout
+});
+```
+
+## Real-World Example: Extension Connector
+
+From the [extension-connector example](https://github.com/WebMCP-org/examples/tree/main/extension-connector):
+
+```typescript
+// background.ts
+import { ExtensionClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+const TARGET_EXTENSION_ID = 'your-mcp-extension-id';
+const PORT_NAME = 'mcp';
+
+async function connectToMcpExtension() {
+  const transport = new ExtensionClientTransport({
+    extensionId: TARGET_EXTENSION_ID,
+    portName: PORT_NAME,
+  });
+  
+  const client = new Client({
+    name: 'extension-client',
+    version: '1.0.0'
+  }, {
+    capabilities: {}
+  });
+  
+  await client.connect(transport);
+  
+  // Now you can call tools exposed by the MCP extension
+  const tools = await client.listTools();
+  console.log('Available tools:', tools);
+  
+  // Call a specific tool
+  const tabs = await client.callTool({
+    name: 'query_tabs',
+    arguments: { active: true }
+  });
+  
+  return { client, tools, tabs };
+}
+```
+
+## Tool Registration Options
+
+Each API tools class accepts configuration options to control which tools are registered:
+
+```typescript
+interface TabsApiToolsOptions {
+  createTab?: boolean;
+  updateTab?: boolean;
+  removeTabs?: boolean;
+  queryTabs?: boolean;
+  getTab?: boolean;
+  duplicateTab?: boolean;
+  highlightTabs?: boolean;
+  moveTabs?: boolean;
+  reloadTab?: boolean;
+  captureVisibleTab?: boolean;
+  executeScript?: boolean;
+  insertCSS?: boolean;
+  removeCSS?: boolean;
+  detectLanguage?: boolean;
+  setZoom?: boolean;
+  getZoom?: boolean;
+  setZoomSettings?: boolean;
+  getZoomSettings?: boolean;
+}
+```
+
+## Input Validation
+
+All tools use Zod schemas for input validation:
+
+```typescript
+// Example: TabsApiTools validation schema
+const createTabSchema = z.object({
+  windowId: z.number().optional(),
+  index: z.number().optional(),
+  url: z.string().optional(),
+  active: z.boolean().optional(),
+  pinned: z.boolean().optional(),
+  openerTabId: z.number().optional()
+});
+
+// The tool automatically validates inputs before execution
+```
+
+## Error Handling
+
+The package provides structured error responses:
+
+```typescript
+try {
+  const result = await client.callTool({
+    name: 'create_tab',
+    arguments: { url: 'invalid-url' }
+  });
+} catch (error) {
+  // Error includes structured information
+  console.error({
+    tool: error.tool,
+    message: error.message,
+    validationErrors: error.validationErrors
+  });
 }
 ```
 
 ## Security Considerations
 
-### Content Security Policy
+### Manifest Permissions
 
-```javascript
-// manifest.json
+Ensure your extension manifest includes required permissions:
+
+```json
 {
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'none'"
-  },
+  "manifest_version": 3,
   "permissions": [
     "tabs",
     "storage",
-    "activeTab"
+    "bookmarks",
+    "history",
+    "downloads"
   ],
   "host_permissions": [
-    "*://*.example.com/*"
-  ]
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  }
 }
 ```
 
-### Message Validation
+### Tool Access Control
+
+Control which tools are exposed:
 
 ```typescript
-import { validateToolCall } from '@mcp-b/extension-tools';
-
-// Validate tool calls before execution
-bridge.onToolCall(async (tool, params) => {
-  // Validate the tool call
-  const validation = validateToolCall(tool, params);
-  
-  if (!validation.valid) {
-    throw new Error(`Invalid tool call: ${validation.error}`);
-  }
-  
-  // Check permissions
-  if (!hasPermission(tool)) {
-    throw new Error(`No permission for tool: ${tool}`);
-  }
-  
-  // Execute tool
-  return await executeToolCall(tool, params);
-});
-```
-
-## Integration Examples
-
-### With Background Service Worker
-
-```typescript
-// background.js
-import { ExtensionTools } from '@mcp-b/extension-tools';
-import { BrowserTransport } from '@mcp-b/transports';
-
-const tools = new ExtensionTools();
-const transport = new BrowserTransport({
-  url: 'ws://localhost:8080'
-});
-
-// Handle incoming MCP requests
-transport.on('request', async (request) => {
-  if (request.method === 'tools/call') {
-    const result = await tools.executeTool(
-      request.params.name,
-      request.params.arguments
-    );
-    return result;
-  }
-});
-```
-
-### With React Extension
-
-```tsx
-// popup.tsx
-import { ExtensionToolsProvider, useExtensionTool } from '@mcp-b/extension-tools/react';
-
-function Popup() {
-  return (
-    <ExtensionToolsProvider>
-      <TabManager />
-    </ExtensionToolsProvider>
-  );
-}
-
-function TabManager() {
-  const callTool = useExtensionTool();
-  const [tabs, setTabs] = useState([]);
-  
-  useEffect(() => {
-    loadTabs();
-  }, []);
-  
-  const loadTabs = async () => {
-    const result = await callTool('tabs.query', {});
-    setTabs(result);
-  };
-  
-  return (
-    <div>
-      {tabs.map(tab => (
-        <TabItem key={tab.id} tab={tab} />
-      ))}
-    </div>
-  );
-}
-```
-
-## Testing
-
-### Mock Extension Environment
-
-```typescript
-import { mockChromeAPI } from '@mcp-b/extension-tools/testing';
-
-describe('Extension Tools', () => {
-  beforeEach(() => {
-    mockChromeAPI({
-      tabs: {
-        query: jest.fn(() => Promise.resolve([
-          { id: 1, url: 'https://example.com' }
-        ]))
-      }
+// Only register specific tools based on permissions
+chrome.permissions.contains({
+  permissions: ['tabs']
+}, (hasPermission) => {
+  if (hasPermission) {
+    const tabsTools = new TabsApiTools(server, {
+      queryTabs: true,  // Read-only operations
+      createTab: false, // Disable creation
+      removeTabs: false // Disable deletion
     });
-  });
-  
-  it('should query tabs', async () => {
-    const tools = new ExtensionTools();
-    const result = await tools.executeTool('tabs.query', {});
-    expect(result).toHaveLength(1);
-  });
+    tabsTools.register();
+  }
 });
 ```
 
-## Troubleshooting
+## Complete API List
 
-### Common Issues
+The package provides wrappers for 62+ Chrome APIs including:
 
-1. **Permission Denied**: Ensure the required permissions are declared in manifest.json
-2. **Tool Not Found**: Check that the Chrome API is available in the current context
-3. **Invalid Parameters**: Verify parameter types match Chrome API documentation
+- **Browser Control**: tabs, windows, browserAction, pageAction
+- **Storage**: storage, cookies, sessions
+- **Content**: bookmarks, history, downloads, topSites
+- **Communication**: runtime, messaging, notifications
+- **DevTools**: debugger, devtools
+- **System**: system.cpu, system.memory, system.storage, system.display
+- **Identity**: identity, oauth2
+- **Enterprise**: enterprise.platformKeys, enterprise.deviceAttributes
+- **Privacy**: privacy, contentSettings
+- **Network**: proxy, vpnProvider, webRequest
+- **Management**: management, permissions, commands
 
-### Debug Mode
+## TypeScript Support
+
+Full TypeScript definitions are provided:
 
 ```typescript
-const tools = new ExtensionTools({
-  debug: true,
-  logger: (level, message, data) => {
-    console.log(`[${level}] ${message}`, data);
-  }
-});
+import type { 
+  TabsApiToolsOptions,
+  StorageApiToolsOptions,
+  BookmarksApiToolsOptions 
+} from '@mcp-b/extension-tools';
+
+// Type-safe tool configuration
+const options: TabsApiToolsOptions = {
+  createTab: true,
+  updateTab: true,
+  removeTabs: false // Explicitly disable dangerous operations
+};
 ```
 
 ## Related Packages
 
-- [@mcp-b/transports](/packages/transports) - Transport layer for MCP
+- [@mcp-b/transports](/packages/transports) - Transport implementations for MCP
+- [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Core MCP SDK
 - [@mcp-b/mcp-react-hooks](/packages/react-hooks) - React hooks for MCP
-- [Chrome Extension Documentation](https://developer.chrome.com/docs/extensions/)
 
 ## Resources
 
 - [GitHub Repository](https://github.com/WebMCP-org/npm-packages)
-- [Extension Examples](https://github.com/WebMCP-org/examples/tree/main/extension-connector)
+- [Extension Connector Example](https://github.com/WebMCP-org/examples/tree/main/extension-connector)
 - [Chrome Extension API Reference](https://developer.chrome.com/docs/extensions/reference/)
+- [MCP Protocol Specification](https://modelcontextprotocol.io)

--- a/packages/react-hook-form.mdx
+++ b/packages/react-hook-form.mdx
@@ -1,603 +1,476 @@
 ---
 title: "@mcp-b/mcp-react-hook-form"
-description: "Seamless integration between React Hook Form and the Model Context Protocol"
+description: "Bridge React Hook Form with MCP to make forms AI-callable with one line of code"
 sidebarTitle: "React Hook Form"
-icon: "rectangle-list"
+icon: "wpforms"
 ---
 
 ## Overview
 
-The `@mcp-b/mcp-react-hook-form` package provides integration between React Hook Form and the Model Context Protocol, enabling form-driven interactions with MCP servers. It simplifies form validation, submission, and state management when working with MCP tools.
+The `@mcp-b/mcp-react-hook-form` package bridges React Hook Form with the Model Context Protocol (MCP), transforming traditional forms into AI-callable tools. With just one line of code, your existing forms become discoverable and usable by AI agents while maintaining all their current functionality.
 
 ## Installation
 
 ```bash
-npm install @mcp-b/mcp-react-hook-form react-hook-form @mcp-b/transports
+npm install @mcp-b/mcp-react-hook-form react-hook-form zod @hookform/resolvers
 ```
 
 ## Key Features
 
-- Automatic form schema generation from MCP tool definitions
-- Built-in validation based on tool input schemas
-- Seamless form submission to MCP tools
-- TypeScript support with inferred types
-- Error handling and retry logic
-- Optimistic updates support
+- **One-line integration** - Add MCP capabilities to existing React Hook Form setups
+- **Headless design** - No UI components, works with any form styling  
+- **Type-safe** - Full TypeScript support with Zod schema inference
+- **Shared validation** - Same validation logic for both users and AI agents
+- **Minimal overhead** - Lightweight bridge between form and MCP server
 
-## Basic Usage
+## Integration Approaches
 
-### Setting up the Provider
+### 1. Direct Integration (Recommended)
+
+The simplest approach for adding MCP capabilities to a form:
 
 ```tsx
-import { MCPFormProvider } from '@mcp-b/mcp-react-hook-form';
-import { MCPProvider } from '@mcp-b/mcp-react-hooks';
-import { BrowserTransport } from '@mcp-b/transports';
+import { useMcpToolFormDirect } from '@mcp-b/mcp-react-hook-form';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
 
-const transport = new BrowserTransport({
-  url: 'ws://localhost:8080'
+const contactSchema = z.object({
+  email: z.string().email('Invalid email address'),
+  subject: z.string().min(5, 'Subject too short'),
+  message: z.string().min(10, 'Message too short')
 });
 
+type ContactFormData = z.infer<typeof contactSchema>;
+
+function ContactForm({ mcpServer }) {
+  const form = useForm<ContactFormData>({
+    resolver: zodResolver(contactSchema)
+  });
+
+  // One-line MCP enablement
+  useMcpToolFormDirect(mcpServer, "contactForm", form, contactSchema, {
+    title: "Contact Form",
+    description: "Send a contact message to support"
+  });
+
+  const onSubmit = (data: ContactFormData) => {
+    console.log('Form submitted:', data);
+    // Handle form submission
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <input {...form.register("email")} placeholder="Email" />
+      <input {...form.register("subject")} placeholder="Subject" />
+      <textarea {...form.register("message")} placeholder="Message" />
+      <button type="submit">Send</button>
+    </form>
+  );
+}
+```
+
+### 2. Context Provider Approach
+
+For apps with multiple forms, use the context provider:
+
+```tsx
+import { McpServerProvider, useMcpToolForm } from '@mcp-b/mcp-react-hook-form';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Create MCP server
+const mcpServer = new McpServer({
+  name: 'form-server',
+  version: '1.0.0'
+});
+
+// Wrap your app
 function App() {
   return (
-    <MCPProvider transport={transport}>
-      <MCPFormProvider>
-        <YourApp />
-      </MCPFormProvider>
-    </MCPProvider>
+    <McpServerProvider server={mcpServer}>
+      <ContactForm />
+      <FeedbackForm />
+      <SettingsForm />
+    </McpServerProvider>
   );
 }
-```
 
-### Creating MCP-Connected Forms
-
-```tsx
-import { useMCPForm } from '@mcp-b/mcp-react-hook-form';
-
+// Use in any child component
 function ContactForm() {
-  const { register, handleSubmit, errors, isSubmitting } = useMCPForm({
-    tool: 'submit_contact',
-    onSuccess: (result) => {
-      console.log('Form submitted:', result);
-    },
-    onError: (error) => {
-      console.error('Submission failed:', error);
-    }
+  const form = useForm<ContactFormData>({
+    resolver: zodResolver(contactSchema)
+  });
+
+  // Register form with MCP
+  useMcpToolForm("contactForm", form, contactSchema, {
+    title: "Contact Form",
+    description: "Send a message to support"
   });
 
   return (
-    <form onSubmit={handleSubmit}>
-      <input 
-        {...register('name')} 
-        placeholder="Name"
-      />
-      {errors.name && <span>{errors.name.message}</span>}
-      
-      <input 
-        {...register('email')} 
-        placeholder="Email"
-      />
-      {errors.email && <span>{errors.email.message}</span>}
-      
-      <textarea 
-        {...register('message')} 
-        placeholder="Message"
-      />
-      {errors.message && <span>{errors.message.message}</span>}
-      
-      <button type="submit" disabled={isSubmitting}>
-        {isSubmitting ? 'Sending...' : 'Send'}
-      </button>
-    </form>
-  );
-}
-```
-
-## Advanced Features
-
-### Auto-Generated Forms
-
-Generate forms automatically from MCP tool schemas:
-
-```tsx
-import { AutoForm } from '@mcp-b/mcp-react-hook-form';
-
-function DynamicForm() {
-  return (
-    <AutoForm
-      tool="create_user"
-      onSubmit={(result) => {
-        console.log('User created:', result);
-      }}
-      fieldConfig={{
-        password: { type: 'password' },
-        bio: { type: 'textarea', rows: 4 }
-      }}
-    />
-  );
-}
-```
-
-### Custom Field Components
-
-```tsx
-import { useController } from '@mcp-b/mcp-react-hook-form';
-
-function CustomInput({ name, control, rules }) {
-  const {
-    field,
-    fieldState: { error, isDirty, isTouched }
-  } = useController({
-    name,
-    control,
-    rules
-  });
-
-  return (
-    <div className={`field ${error ? 'error' : ''}`}>
-      <input {...field} />
-      {error && <span className="error-message">{error.message}</span>}
-      {isDirty && <span className="dirty-indicator">Modified</span>}
-    </div>
-  );
-}
-```
-
-### Schema-Based Validation
-
-```tsx
-const { register, handleSubmit } = useMCPForm({
-  tool: 'create_product',
-  // Validation is automatically derived from tool's input schema
-  validationMode: 'onChange',
-  defaultValues: {
-    name: '',
-    price: 0,
-    category: 'general'
-  }
-});
-```
-
-### Multi-Step Forms
-
-```tsx
-import { useMultiStepMCPForm } from '@mcp-b/mcp-react-hook-form';
-
-function WizardForm() {
-  const {
-    currentStep,
-    steps,
-    next,
-    previous,
-    isFirstStep,
-    isLastStep,
-    register,
-    handleSubmit
-  } = useMultiStepMCPForm({
-    tools: ['validate_email', 'create_profile', 'setup_preferences'],
-    onComplete: (results) => {
-      console.log('All steps completed:', results);
-    }
-  });
-
-  return (
-    <div>
-      <h2>Step {currentStep + 1} of {steps.length}</h2>
-      
-      <form onSubmit={handleSubmit}>
-        {currentStep === 0 && <EmailStep register={register} />}
-        {currentStep === 1 && <ProfileStep register={register} />}
-        {currentStep === 2 && <PreferencesStep register={register} />}
-        
-        <div>
-          {!isFirstStep && (
-            <button type="button" onClick={previous}>
-              Previous
-            </button>
-          )}
-          
-          <button type="submit">
-            {isLastStep ? 'Complete' : 'Next'}
-          </button>
-        </div>
-      </form>
-    </div>
-  );
-}
-```
-
-## Form Utilities
-
-### Field Arrays
-
-```tsx
-import { useFieldArray } from '@mcp-b/mcp-react-hook-form';
-
-function ItemsList() {
-  const { control, register } = useMCPForm({ tool: 'save_items' });
-  const { fields, append, remove } = useFieldArray({
-    control,
-    name: 'items'
-  });
-
-  return (
-    <div>
-      {fields.map((field, index) => (
-        <div key={field.id}>
-          <input {...register(`items.${index}.name`)} />
-          <input {...register(`items.${index}.quantity`)} type="number" />
-          <button onClick={() => remove(index)}>Remove</button>
-        </div>
-      ))}
-      
-      <button onClick={() => append({ name: '', quantity: 1 })}>
-        Add Item
-      </button>
-    </div>
-  );
-}
-```
-
-### Conditional Fields
-
-```tsx
-function ConditionalForm() {
-  const { register, watch } = useMCPForm({ tool: 'process_order' });
-  const orderType = watch('orderType');
-
-  return (
-    <form>
-      <select {...register('orderType')}>
-        <option value="standard">Standard</option>
-        <option value="express">Express</option>
-        <option value="custom">Custom</option>
-      </select>
-
-      {orderType === 'express' && (
-        <input 
-          {...register('deliveryTime')} 
-          placeholder="Preferred delivery time"
-        />
-      )}
-
-      {orderType === 'custom' && (
-        <textarea 
-          {...register('customRequirements')} 
-          placeholder="Special requirements"
-        />
-      )}
-    </form>
-  );
-}
-```
-
-### Form State Management
-
-```tsx
-function FormWithState() {
-  const {
-    register,
-    handleSubmit,
-    formState: { 
-      errors, 
-      isSubmitting, 
-      isValid, 
-      isDirty,
-      submitCount 
-    },
-    reset,
-    setError,
-    clearErrors
-  } = useMCPForm({ tool: 'update_settings' });
-
-  const onSubmit = async (data) => {
-    try {
-      await submitToMCP(data);
-      reset(); // Reset form after successful submission
-    } catch (error) {
-      setError('root', { 
-        type: 'manual',
-        message: 'Failed to save settings'
-      });
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={form.handleSubmit(onSubmit)}>
       {/* Form fields */}
-      
-      <div className="form-status">
-        {isDirty && <span>You have unsaved changes</span>}
-        {submitCount > 0 && <span>Attempted {submitCount} times</span>}
-      </div>
-      
-      <button type="submit" disabled={!isValid || isSubmitting}>
-        Save Settings
-      </button>
     </form>
   );
 }
 ```
 
-## Use Cases
+### 3. Imperative API
 
-### Login Form
-
-From the [login example](https://github.com/WebMCP-org/examples):
+For programmatic control and custom handling:
 
 ```tsx
-import { useMCPForm } from '@mcp-b/mcp-react-hook-form';
+import { registerFormAsMcpTool } from '@mcp-b/mcp-react-hook-form';
 
-function LoginForm() {
-  const { register, handleSubmit, errors, setError } = useMCPForm({
-    tool: 'authenticate',
-    onSuccess: (result) => {
-      if (result.token) {
-        localStorage.setItem('token', result.token);
-        window.location.href = '/dashboard';
-      }
-    },
-    onError: (error) => {
-      setError('root', { message: 'Invalid credentials' });
-    }
+function AdvancedForm() {
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema)
   });
 
-  return (
-    <form onSubmit={handleSubmit}>
-      <input
-        {...register('username', { 
-          required: 'Username is required' 
-        })}
-        placeholder="Username"
-      />
-      
-      <input
-        {...register('password', { 
-          required: 'Password is required',
-          minLength: { value: 8, message: 'Minimum 8 characters' }
-        })}
-        type="password"
-        placeholder="Password"
-      />
-      
-      {errors.root && (
-        <div className="error">{errors.root.message}</div>
-      )}
-      
-      <button type="submit">Login</button>
-    </form>
-  );
-}
-```
-
-### Dynamic Survey Form
-
-```tsx
-function SurveyForm({ surveyId }) {
-  const [schema, setSchema] = useState(null);
-  
   useEffect(() => {
-    // Fetch survey schema from MCP
-    fetchSurveySchema(surveyId).then(setSchema);
-  }, [surveyId]);
-
-  if (!schema) return <Loading />;
-
-  return (
-    <AutoForm
-      schema={schema}
-      tool="submit_survey"
-      toolParams={{ surveyId }}
-      onSubmit={(result) => {
-        alert('Thank you for your response!');
-      }}
-    />
-  );
-}
-```
-
-### File Upload Form
-
-```tsx
-function FileUploadForm() {
-  const { register, handleSubmit, setValue, watch } = useMCPForm({
-    tool: 'upload_document'
-  });
-  
-  const selectedFile = watch('file');
-
-  const handleFileChange = (e) => {
-    const file = e.target.files[0];
-    if (file) {
-      // Convert to base64 for MCP transport
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        setValue('fileData', reader.result);
-        setValue('fileName', file.name);
-        setValue('fileType', file.type);
-      };
-      reader.readAsDataURL(file);
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <input
-        type="file"
-        onChange={handleFileChange}
-        accept=".pdf,.doc,.docx"
-      />
+    const cleanup = registerFormAsMcpTool(mcpServer, "advancedForm", form, schema, {
+      title: "Advanced Form",
+      description: "Complex form with custom handling",
       
-      {selectedFile && (
-        <div>
-          <p>Selected: {watch('fileName')}</p>
-          <p>Type: {watch('fileType')}</p>
-        </div>
-      )}
-      
-      <input
-        {...register('description')}
-        placeholder="Document description"
-      />
-      
-      <button type="submit">Upload</button>
-    </form>
-  );
-}
-```
-
-## TypeScript Integration
-
-### Typed Forms
-
-```tsx
-import { createTypedMCPForm } from '@mcp-b/mcp-react-hook-form';
-
-interface UserFormData {
-  name: string;
-  email: string;
-  age: number;
-  preferences: {
-    newsletter: boolean;
-    notifications: boolean;
-  };
-}
-
-const useUserForm = createTypedMCPForm<UserFormData>('create_user');
-
-function TypedUserForm() {
-  const { register, handleSubmit } = useUserForm({
-    defaultValues: {
-      preferences: {
-        newsletter: true,
-        notifications: false
+      // Custom handler for AI submissions
+      onToolCall: async (data) => {
+        console.log("AI submitted form with:", data);
+        
+        // Custom validation or preprocessing
+        if (!validateBusinessRules(data)) {
+          throw new Error("Business rules validation failed");
+        }
+        
+        // Submit to API
+        const result = await submitToAPI(data);
+        
+        // Return response to AI
+        return {
+          content: [{
+            type: 'text',
+            text: `Form submitted successfully. ID: ${result.id}`
+          }]
+        };
       }
-    }
-  });
+    });
 
-  // All form fields are fully typed
+    return cleanup; // Unregister on unmount
+  }, [mcpServer, form]);
+
   return (
-    <form onSubmit={handleSubmit}>
-      <input {...register('name')} />
-      <input {...register('email')} />
-      <input {...register('age')} type="number" />
-      <input {...register('preferences.newsletter')} type="checkbox" />
-      <input {...register('preferences.notifications')} type="checkbox" />
-      <button type="submit">Create User</button>
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      {/* Form fields */}
     </form>
   );
 }
 ```
 
-### Custom Validation Types
+## Real-World Examples
+
+### Multi-Step Form with AI Support
 
 ```tsx
-import { ValidationRule } from '@mcp-b/mcp-react-hook-form';
+import { useMcpToolFormDirect } from '@mcp-b/mcp-react-hook-form';
+import { useState } from 'react';
 
-interface CustomValidation extends ValidationRule {
-  asyncValidate?: (value: any) => Promise<boolean>;
-  customMessage?: string;
-}
+const registrationSchema = z.object({
+  // Step 1
+  email: z.string().email(),
+  password: z.string().min(8),
+  
+  // Step 2
+  firstName: z.string().min(2),
+  lastName: z.string().min(2),
+  
+  // Step 3
+  company: z.string().optional(),
+  role: z.enum(['developer', 'designer', 'manager', 'other'])
+});
 
-const customValidation: CustomValidation = {
-  validate: async (value) => {
-    const isValid = await checkValueOnServer(value);
-    return isValid || 'This value is already taken';
-  }
-};
-```
-
-## Performance Optimization
-
-### Debounced Validation
-
-```tsx
-import { useDebouncedValidation } from '@mcp-b/mcp-react-hook-form';
-
-function SearchForm() {
-  const { register, errors } = useMCPForm({
-    tool: 'search',
+function RegistrationForm({ mcpServer }) {
+  const [step, setStep] = useState(1);
+  const form = useForm({
+    resolver: zodResolver(registrationSchema),
     mode: 'onChange'
   });
 
-  const validateSearch = useDebouncedValidation(async (value) => {
-    const suggestions = await callTool('get_suggestions', { query: value });
-    return suggestions.length > 0 || 'No results found';
-  }, 500);
+  // Make form AI-callable
+  useMcpToolFormDirect(mcpServer, "registration", form, registrationSchema, {
+    title: "User Registration",
+    description: "Register a new user account",
+    onToolCall: async (data) => {
+      // AI can fill entire form at once
+      await createUser(data);
+      return {
+        content: [{
+          type: 'text',
+          text: `User ${data.email} registered successfully`
+        }]
+      };
+    }
+  });
 
   return (
-    <input
-      {...register('query', { validate: validateSearch })}
-      placeholder="Search..."
-    />
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      {step === 1 && (
+        <>
+          <input {...form.register("email")} placeholder="Email" />
+          <input {...form.register("password")} type="password" />
+        </>
+      )}
+      
+      {step === 2 && (
+        <>
+          <input {...form.register("firstName")} placeholder="First Name" />
+          <input {...form.register("lastName")} placeholder="Last Name" />
+        </>
+      )}
+      
+      {step === 3 && (
+        <>
+          <input {...form.register("company")} placeholder="Company (optional)" />
+          <select {...form.register("role")}>
+            <option value="developer">Developer</option>
+            <option value="designer">Designer</option>
+            <option value="manager">Manager</option>
+            <option value="other">Other</option>
+          </select>
+        </>
+      )}
+      
+      <button type="button" onClick={() => setStep(s => s - 1)} disabled={step === 1}>
+        Previous
+      </button>
+      <button type="button" onClick={() => setStep(s => s + 1)} disabled={step === 3}>
+        Next
+      </button>
+      {step === 3 && <button type="submit">Register</button>}
+    </form>
   );
 }
 ```
 
-### Lazy Field Registration
+### Dynamic Form with Field Dependencies
 
 ```tsx
-function LargeForm() {
-  const { register, handleSubmit } = useMCPForm({
-    tool: 'submit_application',
-    lazyFields: true // Only register fields when they're rendered
+const dynamicSchema = z.object({
+  productType: z.enum(['physical', 'digital', 'service']),
+  productName: z.string().min(3),
+  price: z.number().positive(),
+  
+  // Only for physical products
+  weight: z.number().optional(),
+  dimensions: z.string().optional(),
+  
+  // Only for digital products
+  fileSize: z.number().optional(),
+  downloadUrl: z.string().url().optional(),
+  
+  // Only for services
+  duration: z.number().optional(),
+  availability: z.string().optional()
+}).refine((data) => {
+  if (data.productType === 'physical') {
+    return data.weight && data.dimensions;
+  }
+  if (data.productType === 'digital') {
+    return data.fileSize && data.downloadUrl;
+  }
+  if (data.productType === 'service') {
+    return data.duration && data.availability;
+  }
+  return true;
+}, {
+  message: "Required fields missing for product type"
+});
+
+function ProductForm({ mcpServer }) {
+  const form = useForm({
+    resolver: zodResolver(dynamicSchema)
+  });
+  
+  const productType = form.watch('productType');
+
+  useMcpToolFormDirect(mcpServer, "productForm", form, dynamicSchema, {
+    title: "Product Creation",
+    description: "Create a new product listing"
   });
 
-  const [currentSection, setCurrentSection] = useState(0);
-
   return (
-    <form onSubmit={handleSubmit}>
-      {currentSection === 0 && <PersonalInfo register={register} />}
-      {currentSection === 1 && <Education register={register} />}
-      {currentSection === 2 && <Experience register={register} />}
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <select {...form.register("productType")}>
+        <option value="physical">Physical</option>
+        <option value="digital">Digital</option>
+        <option value="service">Service</option>
+      </select>
       
-      <button onClick={() => setCurrentSection(s => s + 1)}>
-        Next Section
-      </button>
+      <input {...form.register("productName")} placeholder="Product Name" />
+      <input {...form.register("price", { valueAsNumber: true })} type="number" />
+      
+      {productType === 'physical' && (
+        <>
+          <input {...form.register("weight", { valueAsNumber: true })} type="number" placeholder="Weight (kg)" />
+          <input {...form.register("dimensions")} placeholder="Dimensions (LxWxH)" />
+        </>
+      )}
+      
+      {productType === 'digital' && (
+        <>
+          <input {...form.register("fileSize", { valueAsNumber: true })} type="number" placeholder="File Size (MB)" />
+          <input {...form.register("downloadUrl")} placeholder="Download URL" />
+        </>
+      )}
+      
+      {productType === 'service' && (
+        <>
+          <input {...form.register("duration", { valueAsNumber: true })} type="number" placeholder="Duration (hours)" />
+          <input {...form.register("availability")} placeholder="Availability" />
+        </>
+      )}
+      
+      <button type="submit">Create Product</button>
     </form>
   );
 }
+```
+
+## Hook Options
+
+### useMcpToolFormDirect Options
+
+```typescript
+interface UseMcpToolFormOptions {
+  title?: string;              // Tool display name
+  description?: string;        // Tool description for AI
+  onToolCall?: (data: any) => Promise<any>; // Custom handler
+  validateBeforeSubmit?: boolean; // Validate before AI submission
+  debounceMs?: number;        // Debounce registration updates
+}
+```
+
+### registerFormAsMcpTool Options
+
+```typescript
+interface RegisterFormOptions {
+  title?: string;
+  description?: string;
+  onToolCall?: (data: any) => Promise<any>;
+  onError?: (error: Error) => void;
+  transformInput?: (data: any) => any;  // Transform AI input
+  transformOutput?: (data: any) => any; // Transform response
+}
+```
+
+## TypeScript Support
+
+Full TypeScript support with automatic type inference:
+
+```tsx
+import type { z } from 'zod';
+
+// Schema defines both form and MCP tool types
+const schema = z.object({
+  name: z.string(),
+  age: z.number(),
+  email: z.string().email()
+});
+
+// Types are automatically inferred
+type FormData = z.infer<typeof schema>;
+
+function TypedForm({ mcpServer }) {
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema)
+  });
+
+  // Types flow through to MCP tool
+  useMcpToolFormDirect(mcpServer, "typedForm", form, schema);
+  
+  return (
+    <form onSubmit={form.handleSubmit((data: FormData) => {
+      // data is fully typed
+    })}>
+      {/* Form fields */}
+    </form>
+  );
+}
+```
+
+## AI Agent Usage
+
+Once registered, AI agents can discover and use your forms:
+
+```typescript
+// AI agent code
+const tools = await mcpClient.listTools();
+// Returns: [{ name: "contactForm", description: "Send a contact message", ... }]
+
+// AI can submit the form
+const result = await mcpClient.callTool({
+  name: "contactForm",
+  arguments: {
+    email: "user@example.com",
+    subject: "Question about pricing",
+    message: "I'd like to know more about your enterprise plans."
+  }
+});
 ```
 
 ## Testing
 
-### Mock MCP Form Provider
-
 ```tsx
-import { MockMCPFormProvider } from '@mcp-b/mcp-react-hook-form/testing';
+import { render, screen } from '@testing-library/react';
+import { MockMcpServer } from '@mcp-b/mcp-react-hook-form/testing';
 
 describe('ContactForm', () => {
-  it('submits form data', async () => {
-    const onSubmit = jest.fn();
+  it('registers form as MCP tool', async () => {
+    const mockServer = new MockMcpServer();
     
-    render(
-      <MockMCPFormProvider mockSubmit={onSubmit}>
-        <ContactForm />
-      </MockMCPFormProvider>
+    render(<ContactForm mcpServer={mockServer} />);
+    
+    const tools = mockServer.getRegisteredTools();
+    expect(tools).toContainEqual(
+      expect.objectContaining({
+        name: 'contactForm',
+        description: 'Send a contact message'
+      })
     );
+  });
+  
+  it('handles AI form submission', async () => {
+    const mockServer = new MockMcpServer();
     
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
-      target: { value: 'John Doe' }
+    render(<ContactForm mcpServer={mockServer} />);
+    
+    const result = await mockServer.callTool('contactForm', {
+      email: 'test@example.com',
+      subject: 'Test',
+      message: 'Test message'
     });
     
-    fireEvent.click(screen.getByText('Send'));
-    
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({
-        name: 'John Doe'
-      });
-    });
+    expect(result.content[0].text).toContain('success');
   });
 });
 ```
 
+## Best Practices
+
+1. **Use descriptive tool names** - Help AI agents understand what each form does
+2. **Provide clear descriptions** - Include expected input format and purpose
+3. **Validate consistently** - Use the same Zod schema for both UI and AI validation
+4. **Handle errors gracefully** - Provide meaningful error messages for AI agents
+5. **Test AI interactions** - Ensure forms work correctly when called programmatically
+
 ## Related Packages
 
 - [@mcp-b/mcp-react-hooks](/packages/react-hooks) - React hooks for MCP
-- [@mcp-b/transports](/packages/transports) - Transport layer for MCP
-- [React Hook Form Documentation](https://react-hook-form.com)
+- [react-hook-form](https://react-hook-form.com) - Performant forms library
+- [@hookform/resolvers](https://www.npmjs.com/package/@hookform/resolvers) - Validation resolvers
+- [zod](https://zod.dev) - TypeScript-first schema validation
 
 ## Resources
 
 - [GitHub Repository](https://github.com/WebMCP-org/npm-packages)
-- [Examples](https://github.com/WebMCP-org/examples)
 - [React Hook Form Documentation](https://react-hook-form.com)
+- [MCP Protocol Specification](https://modelcontextprotocol.io)
+- [Zod Documentation](https://zod.dev)

--- a/packages/react-hooks.mdx
+++ b/packages/react-hooks.mdx
@@ -1,301 +1,380 @@
 ---
 title: "@mcp-b/mcp-react-hooks"
-description: "React hooks for seamless MCP integration in React applications"
+description: "React hooks and providers for MCP integration in browser applications"
 sidebarTitle: "React Hooks"
 icon: "react"
 ---
 
 ## Overview
 
-The `@mcp-b/mcp-react-hooks` package provides React-friendly APIs and hooks for integrating the Model Context Protocol into React applications. It offers a declarative way to interact with MCP servers and manage connection state.
+The `@mcp-b/mcp-react-hooks` package provides React hooks and context providers for integrating the Model Context Protocol (MCP) into React applications. It supports both client and server functionality with automatic connection management.
 
 ## Installation
 
 ```bash
-npm install @mcp-b/mcp-react-hooks @mcp-b/transports
+npm install @mcp-b/mcp-react-hooks @mcp-b/transports @modelcontextprotocol/sdk
 ```
 
-## Key Features
+## Providers and Hooks
 
-- Ready-to-use React hooks
-- Automatic connection management
-- Built-in error handling and retry logic
-- TypeScript support
-- Server-side rendering compatible
-- Optimized re-renders with proper memoization
+### McpClientProvider & useMcpClient
 
-## Basic Usage
-
-### Setting up the Provider
+Connect to an MCP server and consume its tools and resources.
 
 ```tsx
-import { MCPProvider } from '@mcp-b/mcp-react-hooks';
-import { BrowserTransport } from '@mcp-b/transports';
+import { McpClientProvider, useMcpClient } from '@mcp-b/mcp-react-hooks';
+import { TabClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
-const transport = new BrowserTransport({
-  url: 'ws://localhost:8080'
+// Create transport and client
+const transport = new TabClientTransport({
+  targetOrigin: window.location.origin
 });
 
+const client = new Client({
+  name: 'my-app',
+  version: '1.0.0'
+}, {
+  capabilities: {}
+});
+
+// Wrap your app
 function App() {
   return (
-    <MCPProvider transport={transport}>
-      <YourApp />
-    </MCPProvider>
-  );
-}
-```
-
-### Using MCP Hooks
-
-```tsx
-import { useMCP, useTools, useCallTool } from '@mcp-b/mcp-react-hooks';
-
-function TodoList() {
-  const { connected, error } = useMCP();
-  const { tools, loading } = useTools();
-  const callTool = useCallTool();
-
-  const handleAddTodo = async (text: string) => {
-    try {
-      const result = await callTool('add_todo', { text });
-      console.log('Todo added:', result);
-    } catch (error) {
-      console.error('Failed to add todo:', error);
-    }
-  };
-
-  if (!connected) return <div>Connecting...</div>;
-  if (error) return <div>Error: {error.message}</div>;
-  if (loading) return <div>Loading tools...</div>;
-
-  return (
-    <div>
-      {/* Your todo list UI */}
-    </div>
-  );
-}
-```
-
-## Hooks API
-
-### useMCP
-
-Access the MCP connection state and client instance.
-
-```tsx
-const { client, connected, connecting, error } = useMCP();
-```
-
-**Returns:**
-- `client`: MCP client instance
-- `connected`: Boolean indicating connection status
-- `connecting`: Boolean indicating if currently connecting
-- `error`: Error object if connection failed
-
-### useTools
-
-List available MCP tools.
-
-```tsx
-const { tools, loading, error, refetch } = useTools();
-```
-
-**Returns:**
-- `tools`: Array of available tools
-- `loading`: Boolean indicating if tools are being fetched
-- `error`: Error object if fetching failed
-- `refetch`: Function to manually refetch tools
-
-### useCallTool
-
-Get a function to call MCP tools.
-
-```tsx
-const callTool = useCallTool();
-
-// Usage
-const result = await callTool('tool_name', { 
-  param1: 'value1',
-  param2: 'value2'
-});
-```
-
-### useResources
-
-List and manage MCP resources.
-
-```tsx
-const { resources, loading, error, refetch } = useResources();
-```
-
-### usePrompts
-
-Access available prompts from the MCP server.
-
-```tsx
-const { prompts, loading, error } = usePrompts();
-```
-
-### useSubscription
-
-Subscribe to MCP server notifications.
-
-```tsx
-useSubscription('document/update', (params) => {
-  console.log('Document updated:', params);
-});
-```
-
-## Advanced Usage
-
-### Custom Hook Configuration
-
-```tsx
-import { createMCPHooks } from '@mcp-b/mcp-react-hooks';
-
-// Create custom hooks with specific configuration
-const { useMCP, useTools } = createMCPHooks({
-  reconnectOnError: true,
-  retryAttempts: 3,
-  retryDelay: 1000
-});
-```
-
-### Error Boundaries
-
-```tsx
-import { MCPErrorBoundary } from '@mcp-b/mcp-react-hooks';
-
-function App() {
-  return (
-    <MCPErrorBoundary fallback={<ErrorFallback />}>
-      <MCPProvider transport={transport}>
-        <YourApp />
-      </MCPProvider>
-    </MCPErrorBoundary>
+    <McpClientProvider client={client} transport={transport}>
+      <MyComponent />
+    </McpClientProvider>
   );
 }
 
-function ErrorFallback({ error, retry }) {
-  return (
-    <div>
-      <p>MCP connection failed: {error.message}</p>
-      <button onClick={retry}>Retry</button>
-    </div>
-  );
-}
-```
+// Use the hook
+function MyComponent() {
+  const { 
+    client, 
+    tools, 
+    resources, 
+    isConnected, 
+    isLoading, 
+    error,
+    capabilities,
+    reconnect
+  } = useMcpClient();
 
-### Optimistic Updates
-
-```tsx
-function TodoList() {
-  const [todos, setTodos] = useState([]);
-  const callTool = useCallTool();
-
-  const addTodo = async (text: string) => {
-    // Optimistic update
-    const tempId = Date.now();
-    setTodos(prev => [...prev, { id: tempId, text, pending: true }]);
-
-    try {
-      const result = await callTool('add_todo', { text });
-      // Replace temp todo with real one
-      setTodos(prev => 
-        prev.map(todo => 
-          todo.id === tempId ? { ...result, pending: false } : todo
-        )
-      );
-    } catch (error) {
-      // Rollback on error
-      setTodos(prev => prev.filter(todo => todo.id !== tempId));
-      throw error;
-    }
-  };
-
-  return (
-    // Your UI
-  );
-}
-```
-
-## Use Cases
-
-### Voice Agent with React Flow
-
-From the [reactFlowVoiceAgent example](https://github.com/WebMCP-org/examples):
-
-```tsx
-import { useMCP, useCallTool } from '@mcp-b/mcp-react-hooks';
-import ReactFlow from 'reactflow';
-
-function VoiceAgent() {
-  const { connected } = useMCP();
-  const callTool = useCallTool();
-
-  const handleVoiceCommand = async (transcript: string) => {
-    const result = await callTool('process_voice_command', {
-      transcript,
-      context: getCurrentFlowContext()
-    });
+  const handleCallTool = async () => {
+    if (!client) return;
     
-    updateFlowBasedOnResult(result);
+    const result = await client.callTool({
+      name: 'myTool',
+      arguments: { text: 'Hello' }
+    });
+    console.log(result);
   };
+
+  if (!isConnected) return <div>Connecting...</div>;
+  if (error) return <div>Error: {error.message}</div>;
 
   return (
     <div>
-      <ReactFlow />
-      <VoiceInput onTranscript={handleVoiceCommand} />
+      <h3>Available Tools: {tools.length}</h3>
+      <button onClick={handleCallTool}>Call Tool</button>
+      <button onClick={reconnect}>Reconnect</button>
     </div>
   );
 }
 ```
 
-### Form Integration
+### McpServerProvider & useMcpServer
+
+Create an MCP server that exposes tools to clients.
 
 ```tsx
-import { useForm } from 'react-hook-form';
-import { useCallTool } from '@mcp-b/mcp-react-hooks';
+import { McpServerProvider, useMcpServer } from '@mcp-b/mcp-react-hooks';
+import { TabServerTransport } from '@mcp-b/transports';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 
-function ContactForm() {
-  const { register, handleSubmit } = useForm();
-  const callTool = useCallTool();
+// Create server and transport
+const server = new McpServer({
+  name: 'my-server',
+  version: '1.0.0'
+});
 
-  const onSubmit = async (data) => {
-    await callTool('submit_contact', data);
+const transport = new TabServerTransport({
+  allowedOrigins: ['*']
+});
+
+// Wrap your app
+function App() {
+  return (
+    <McpServerProvider server={server} transport={transport}>
+      <ServerComponent />
+    </McpServerProvider>
+  );
+}
+
+// Use the hook
+function ServerComponent() {
+  const { 
+    server, 
+    isConnected, 
+    isConnecting, 
+    error,
+    registerTool,
+    elicitInput
+  } = useMcpServer();
+
+  useEffect(() => {
+    // Register a tool dynamically
+    const unregister = registerTool('greet', {
+      description: 'Greets a user',
+      inputSchema: z.object({
+        name: z.string().describe('Name to greet')
+      }),
+      handler: async ({ name }) => ({
+        content: [{ 
+          type: 'text', 
+          text: `Hello, ${name}!` 
+        }]
+      })
+    });
+
+    // Cleanup on unmount
+    return unregister;
+  }, [registerTool]);
+
+  const handleElicit = async () => {
+    const result = await elicitInput(
+      'Enter your name',
+      { type: 'string' }
+    );
+    console.log('User entered:', result);
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <input {...register('name')} />
-      <input {...register('email')} />
-      <textarea {...register('message')} />
-      <button type="submit">Send</button>
-    </form>
+    <div>
+      <p>Server status: {isConnected ? 'Connected' : 'Disconnected'}</p>
+      <button onClick={handleElicit}>Request Input</button>
+    </div>
   );
 }
 ```
 
-### Real-time Dashboard
+### McpMemoryProvider
+
+Combines both client and server functionality using an in-memory transport, perfect for self-contained applications.
 
 ```tsx
-function Dashboard() {
-  const [metrics, setMetrics] = useState({});
-  
-  useSubscription('metrics/update', (data) => {
-    setMetrics(prev => ({ ...prev, ...data }));
-  });
+import { McpMemoryProvider } from '@mcp-b/mcp-react-hooks';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-  const { tools } = useTools();
-  const refreshTool = tools?.find(t => t.name === 'refresh_metrics');
+const server = new McpServer({
+  name: 'memory-server',
+  version: '1.0.0'
+});
+
+function App() {
+  return (
+    <McpMemoryProvider server={server}>
+      <CombinedComponent />
+    </McpMemoryProvider>
+  );
+}
+
+function CombinedComponent() {
+  // Can use both hooks
+  const { tools } = useMcpClient();
+  const { registerTool } = useMcpServer();
+
+  useEffect(() => {
+    const unregister = registerTool('echo', {
+      description: 'Echoes input',
+      inputSchema: z.object({ message: z.string() }),
+      handler: async ({ message }) => ({
+        content: [{ type: 'text', text: message }]
+      })
+    });
+    return unregister;
+  }, [registerTool]);
 
   return (
     <div>
-      <MetricsDisplay data={metrics} />
-      {refreshTool && (
-        <button onClick={() => callTool('refresh_metrics')}>
-          Refresh
-        </button>
+      <h3>Self-contained MCP app</h3>
+      <p>Tools available: {tools.length}</p>
+    </div>
+  );
+}
+```
+
+## Hook Return Values
+
+### useMcpClient Returns
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `client` | `Client` | MCP client instance |
+| `tools` | `McpTool[]` | Available tools from server |
+| `resources` | `Resource[]` | Available resources |
+| `isConnected` | `boolean` | Connection status |
+| `isLoading` | `boolean` | Loading state |
+| `error` | `Error \| null` | Connection error if any |
+| `capabilities` | `ServerCapabilities \| null` | Server capabilities |
+| `reconnect` | `() => Promise<void>` | Manual reconnection function |
+
+### useMcpServer Returns
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `server` | `McpServer` | MCP server instance |
+| `isConnected` | `boolean` | Connection status |
+| `isConnecting` | `boolean` | Connection in progress |
+| `error` | `Error \| null` | Connection error if any |
+| `registerTool` | `Function` | Register a tool dynamically |
+| `elicitInput` | `Function` | Request input from client |
+
+## Real-World Patterns
+
+### Dynamic Tool Registration
+
+```tsx
+function DynamicToolsComponent() {
+  const { registerTool } = useMcpServer();
+  const [registeredTools, setRegisteredTools] = useState([]);
+
+  const addCalculatorTool = () => {
+    const unregister = registerTool('calculate', {
+      description: 'Performs basic calculations',
+      inputSchema: z.object({
+        operation: z.enum(['add', 'subtract', 'multiply', 'divide']),
+        a: z.number(),
+        b: z.number()
+      }),
+      handler: async ({ operation, a, b }) => {
+        let result;
+        switch (operation) {
+          case 'add': result = a + b; break;
+          case 'subtract': result = a - b; break;
+          case 'multiply': result = a * b; break;
+          case 'divide': result = a / b; break;
+        }
+        return {
+          content: [{ 
+            type: 'text', 
+            text: `Result: ${result}` 
+          }]
+        };
+      }
+    });
+
+    setRegisteredTools(prev => [...prev, { name: 'calculate', unregister }]);
+  };
+
+  return (
+    <div>
+      <button onClick={addCalculatorTool}>Add Calculator Tool</button>
+      {registeredTools.map(tool => (
+        <div key={tool.name}>
+          {tool.name} 
+          <button onClick={() => tool.unregister()}>Remove</button>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+### Error Handling
+
+```tsx
+function RobustMcpComponent() {
+  const { client, error, reconnect, isConnected } = useMcpClient();
+  const [callError, setCallError] = useState(null);
+
+  const safeCallTool = async (toolName, args) => {
+    setCallError(null);
+    try {
+      const result = await client.callTool({
+        name: toolName,
+        arguments: args
+      });
+      return result;
+    } catch (err) {
+      setCallError(err);
+      console.error('Tool call failed:', err);
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="error-state">
+        <p>Connection error: {error.message}</p>
+        <button onClick={reconnect}>Try Reconnecting</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>Status: {isConnected ? '🟢 Connected' : '🔴 Disconnected'}</p>
+      {callError && <p className="error">Last error: {callError.message}</p>}
+      <button onClick={() => safeCallTool('myTool', {})}>
+        Call Tool Safely
+      </button>
+    </div>
+  );
+}
+```
+
+### Tool Discovery UI
+
+```tsx
+function ToolExplorer() {
+  const { tools, client } = useMcpClient();
+  const [selectedTool, setSelectedTool] = useState(null);
+  const [args, setArgs] = useState({});
+  const [result, setResult] = useState(null);
+
+  const executeTool = async () => {
+    if (!selectedTool) return;
+    
+    const response = await client.callTool({
+      name: selectedTool.name,
+      arguments: args
+    });
+    setResult(response);
+  };
+
+  return (
+    <div>
+      <select onChange={(e) => {
+        const tool = tools.find(t => t.name === e.target.value);
+        setSelectedTool(tool);
+        setArgs({});
+      }}>
+        <option>Select a tool</option>
+        {tools.map(tool => (
+          <option key={tool.name} value={tool.name}>
+            {tool.name}
+          </option>
+        ))}
+      </select>
+
+      {selectedTool && (
+        <div>
+          <h4>{selectedTool.description}</h4>
+          <pre>{JSON.stringify(selectedTool.inputSchema, null, 2)}</pre>
+          <textarea 
+            value={JSON.stringify(args, null, 2)}
+            onChange={(e) => setArgs(JSON.parse(e.target.value))}
+          />
+          <button onClick={executeTool}>Execute</button>
+        </div>
+      )}
+
+      {result && (
+        <div>
+          <h4>Result:</h4>
+          <pre>{JSON.stringify(result, null, 2)}</pre>
+        </div>
       )}
     </div>
   );
@@ -304,146 +383,104 @@ function Dashboard() {
 
 ## TypeScript Support
 
-### Custom Types
+The package includes full TypeScript definitions. You can import types for better type safety:
 
 ```tsx
-import { MCPProvider } from '@mcp-b/mcp-react-hooks';
-import type { Tool, Resource } from '@mcp-b/mcp-react-hooks';
+import type { 
+  McpClientProviderProps,
+  McpServerProviderProps,
+  McpMemoryProviderProps
+} from '@mcp-b/mcp-react-hooks';
 
-interface TodoTool extends Tool {
-  name: 'add_todo' | 'remove_todo' | 'update_todo';
-  inputSchema: {
+// Use with your own types
+interface MyTool {
+  name: 'customTool';
+  arguments: {
+    input: string;
+    options?: {
+      format: 'json' | 'text';
+    };
+  };
+}
+
+// Type your responses
+interface ToolResponse {
+  content: Array<{
+    type: 'text' | 'image';
     text?: string;
-    id?: number;
-    completed?: boolean;
-  };
-}
-
-// Use with typed hooks
-const { tools } = useTools<TodoTool>();
-```
-
-### Type-safe Tool Calls
-
-```tsx
-import { createTypedHooks } from '@mcp-b/mcp-react-hooks';
-
-interface MyTools {
-  add_todo: {
-    params: { text: string; priority?: 'low' | 'medium' | 'high' };
-    result: { id: number; text: string; created: Date };
-  };
-  remove_todo: {
-    params: { id: number };
-    result: { success: boolean };
-  };
-}
-
-const { useCallTool } = createTypedHooks<MyTools>();
-
-// Now fully typed
-const result = await useCallTool('add_todo', { 
-  text: 'Hello',
-  priority: 'high' 
-});
-// result is typed as { id: number; text: string; created: Date }
-```
-
-## Performance Optimization
-
-### Memoization
-
-```tsx
-import { useMemo } from 'react';
-import { useTools } from '@mcp-b/mcp-react-hooks';
-
-function ToolsList() {
-  const { tools } = useTools();
-  
-  const categorizedTools = useMemo(() => {
-    return tools?.reduce((acc, tool) => {
-      const category = tool.category || 'general';
-      acc[category] = acc[category] || [];
-      acc[category].push(tool);
-      return acc;
-    }, {});
-  }, [tools]);
-
-  return (
-    // Render categorized tools
-  );
+    data?: string;
+    mimeType?: string;
+  }>;
 }
 ```
 
-### Lazy Loading
+## Integration Examples
+
+### With React Router
 
 ```tsx
-import { lazy, Suspense } from 'react';
-
-const MCPProvider = lazy(() => 
-  import('@mcp-b/mcp-react-hooks').then(m => ({ default: m.MCPProvider }))
-);
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 function App() {
   return (
-    <Suspense fallback={<Loading />}>
-      <MCPProvider transport={transport}>
-        <YourApp />
-      </MCPProvider>
-    </Suspense>
+    <BrowserRouter>
+      <McpClientProvider client={client} transport={transport}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/tools" element={<ToolsPage />} />
+        </Routes>
+      </McpClientProvider>
+    </BrowserRouter>
   );
 }
 ```
 
-## Testing
-
-### Mock Provider
+### With State Management
 
 ```tsx
-import { MockMCPProvider } from '@mcp-b/mcp-react-hooks/testing';
+import { create } from 'zustand';
 
-const mockTools = [
-  { name: 'test_tool', description: 'Test tool' }
-];
+const useMcpStore = create((set) => ({
+  toolResults: [],
+  addToolResult: (result) => set((state) => ({
+    toolResults: [...state.toolResults, result]
+  }))
+}));
 
-describe('MyComponent', () => {
-  it('renders with mocked MCP', () => {
-    render(
-      <MockMCPProvider tools={mockTools}>
-        <MyComponent />
-      </MockMCPProvider>
-    );
-    
-    expect(screen.getByText('test_tool')).toBeInTheDocument();
-  });
-});
-```
+function IntegratedComponent() {
+  const { client } = useMcpClient();
+  const addToolResult = useMcpStore((state) => state.addToolResult);
 
-## Migration Guide
+  const callAndStore = async (toolName, args) => {
+    const result = await client.callTool({
+      name: toolName,
+      arguments: args
+    });
+    addToolResult({ toolName, args, result, timestamp: Date.now() });
+  };
 
-### From Direct Client Usage
-
-```tsx
-// Before
-const client = new McpClient(...);
-await client.connect();
-const tools = await client.listTools();
-
-// After
-function Component() {
-  const { tools } = useTools();
-  // Tools are automatically fetched and updated
+  return <button onClick={() => callAndStore('myTool', {})}>
+    Call and Store
+  </button>;
 }
 ```
 
+## Browser Compatibility
+
+- Chrome/Edge (Chromium): Full support
+- Firefox: Full support for tab transports
+- Safari: Full support for tab transports
+- All browsers require modern JavaScript features (ES2020+)
+
 ## Related Packages
 
-- [@mcp-b/transports](/packages/transports) - Transport layer for MCP
+- [@mcp-b/transports](/packages/transports) - Browser transport implementations
+- [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Core MCP SDK
 - [@mcp-b/mcp-react-hook-form](/packages/react-hook-form) - React Hook Form integration
-- [@mcp-b/extension-tools](/packages/extension-tools) - Chrome Extension tools
 
 ## Resources
 
 - [GitHub Repository](https://github.com/WebMCP-org/npm-packages)
-- [Examples](https://github.com/WebMCP-org/examples)
+- [Working Examples](https://github.com/WebMCP-org/examples)
+- [MCP Protocol Specification](https://modelcontextprotocol.io)
 - [React Documentation](https://react.dev)

--- a/packages/transports.mdx
+++ b/packages/transports.mdx
@@ -1,13 +1,13 @@
 ---
 title: "@mcp-b/transports"
-description: "Browser-specific MCP transport implementations for client-server communication"
+description: "Browser-specific MCP transport implementations for tab and extension communication"
 sidebarTitle: "Transports"
 icon: "arrows-rotate"
 ---
 
 ## Overview
 
-The `@mcp-b/transports` package provides browser-specific transport implementations for the Model Context Protocol (MCP). It enables communication between MCP servers and clients using browser-native mechanisms.
+The `@mcp-b/transports` package provides browser-specific transport implementations for the Model Context Protocol (MCP). It enables communication between MCP servers/clients in browser tabs and Chrome extensions.
 
 ## Installation
 
@@ -15,231 +15,288 @@ The `@mcp-b/transports` package provides browser-specific transport implementati
 npm install @mcp-b/transports
 ```
 
-## Key Features
+## Transport Types
 
-- Browser-native transport mechanisms
-- WebSocket and postMessage support
-- Automatic reconnection handling
-- TypeScript support with full type definitions
+### TabServerTransport
 
-## Basic Usage
-
-### Setting up a Transport
+Used by MCP servers running in browser tabs to accept connections.
 
 ```typescript
-import { BrowserTransport } from '@mcp-b/transports';
+import { TabServerTransport } from '@mcp-b/transports';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
-// Create a new transport instance
-const transport = new BrowserTransport({
-  url: 'ws://localhost:8080',
-  reconnect: true,
-  reconnectInterval: 5000
+// Create MCP server
+const server = new McpServer({
+  name: 'PersonalAIWebsite',
+  version: '1.0.0',
 });
 
-// Connect to the MCP server
-await transport.connect();
-
-// Send messages
-await transport.send({
-  method: 'tools/call',
-  params: {
-    name: 'myTool',
-    arguments: { /* tool arguments */ }
-  }
+// Create transport with allowed origins
+const transport = new TabServerTransport({
+  allowedOrigins: ['*'] // Or specify specific origins for security
 });
 
-// Listen for messages
-transport.on('message', (message) => {
-  console.log('Received:', message);
-});
+// Connect server to transport
+await server.connect(transport);
 ```
 
-### Using with Chrome Extensions
+### TabClientTransport
+
+Used by MCP clients to connect to servers in the same browser context.
 
 ```typescript
-import { ExtensionTransport } from '@mcp-b/transports';
+import { TabClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 
-// Create transport for Chrome extension context
-const transport = new ExtensionTransport({
-  extensionId: 'your-extension-id'
+// Create transport targeting current origin
+const transport = new TabClientTransport({
+  targetOrigin: window.location.origin
 });
 
-// Connect to extension
-await transport.connect();
-
-// Use the transport
-const response = await transport.request({
-  method: 'tools/list'
+// Create and connect MCP client
+const client = new Client({
+  name: 'web-client',
+  version: '1.0.0'
+}, {
+  capabilities: {}
 });
+
+await client.connect(transport);
 ```
 
-## Advanced Configuration
+### ExtensionClientTransport
 
-### Custom Transport Options
+Used to communicate with Chrome extensions that expose MCP servers.
 
 ```typescript
-const transport = new BrowserTransport({
-  // WebSocket endpoint
-  url: 'ws://localhost:8080',
-  
-  // Reconnection settings
-  reconnect: true,
-  reconnectInterval: 5000,
-  maxReconnectAttempts: 10,
-  
-  // Message timeout
-  requestTimeout: 30000,
-  
-  // Custom headers (for WebSocket)
-  headers: {
-    'Authorization': 'Bearer token'
-  }
+import { ExtensionClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+// Create transport for extension communication
+const transport = new ExtensionClientTransport({
+  extensionId: 'your-target-extension-id',
+  portName: 'mcp' // Optional, defaults to 'mcp'
 });
+
+// Connect client
+const client = new Client({
+  name: 'extension-connector',
+  version: '1.0.0'
+}, {
+  capabilities: {}
+});
+
+await client.connect(transport);
 ```
 
-### Error Handling
+## Real-World Examples
 
-```typescript
-transport.on('error', (error) => {
-  console.error('Transport error:', error);
-});
-
-transport.on('disconnect', () => {
-  console.log('Disconnected from server');
-});
-
-transport.on('reconnect', (attempt) => {
-  console.log(`Reconnecting... attempt ${attempt}`);
-});
-```
-
-## Use Cases
-
-### Todo List Application
+### Counter Application (Vanilla TypeScript)
 
 From the [vanilla-ts example](https://github.com/WebMCP-org/examples/tree/main/vanilla-ts):
 
 ```typescript
-import { BrowserTransport } from '@mcp-b/transports';
-import { McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { TabServerTransport } from '@mcp-b/transports';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import z from 'zod';
 
-// Initialize transport
-const transport = new BrowserTransport({
-  url: 'ws://localhost:3000'
+const server = new McpServer({
+  name: 'PersonalAIWebsite',
+  version: '1.0.0',
 });
 
-// Create MCP client
-const client = new McpClient({
-  name: 'todo-app',
-  version: '1.0.0'
-}, {
-  transport: transport
-});
-
-// Connect and use
-await client.connect(transport);
-
-// List available tools
-const tools = await client.listTools();
-
-// Call a tool
-const result = await client.callTool(
-  'add_todo',
-  { text: 'Complete MCP integration' }
-);
-```
-
-### Real-time Collaboration
-
-```typescript
-// Set up transport for real-time updates
-const transport = new BrowserTransport({
-  url: 'wss://collab.example.com',
-  reconnect: true
-});
-
-// Subscribe to updates
-transport.on('notification', (notification) => {
-  if (notification.method === 'document/update') {
-    updateDocument(notification.params);
+// Register tools with the server
+server.addTool({
+  name: 'incrementCounter',
+  description: 'Increment the counter',
+  inputSchema: z.object({}),
+  handler: async () => {
+    counter++;
+    updateDisplay();
+    return {
+      content: [{ 
+        type: 'text', 
+        text: `Counter incremented to ${counter}` 
+      }]
+    };
   }
 });
+
+// Set up transport
+const transport = new TabServerTransport({
+  allowedOrigins: ['*']
+});
+
+// Connect and start serving
+await server.connect(transport);
+console.log('MCP Server running in browser tab');
 ```
 
-## Integration with React
+### React Flow Voice Agent
 
-For React applications, consider using [@mcp-b/mcp-react-hooks](/packages/react-hooks) which provides React-specific abstractions on top of this transport layer.
-
-## API Reference
-
-### BrowserTransport
-
-Main transport class for browser environments.
-
-#### Constructor Options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `url` | `string` | Required | WebSocket endpoint URL |
-| `reconnect` | `boolean` | `true` | Enable automatic reconnection |
-| `reconnectInterval` | `number` | `5000` | Milliseconds between reconnection attempts |
-| `maxReconnectAttempts` | `number` | `Infinity` | Maximum number of reconnection attempts |
-| `requestTimeout` | `number` | `30000` | Request timeout in milliseconds |
-
-#### Methods
-
-- `connect(): Promise<void>` - Establish connection to server
-- `disconnect(): void` - Close the connection
-- `send(message: any): Promise<void>` - Send a message
-- `request(message: any): Promise<any>` - Send a request and wait for response
-- `on(event: string, handler: Function): void` - Subscribe to events
-- `off(event: string, handler: Function): void` - Unsubscribe from events
-
-### ExtensionTransport
-
-Transport implementation for Chrome extensions.
-
-#### Constructor Options
-
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `extensionId` | `string` | Required | Chrome extension ID |
-| `timeout` | `number` | `30000` | Request timeout |
-
-## Troubleshooting
-
-### Connection Issues
-
-If you're experiencing connection problems:
-
-1. Verify the WebSocket URL is correct and accessible
-2. Check browser console for CORS errors
-3. Ensure the MCP server is running and listening
-4. Verify firewall settings allow WebSocket connections
-
-### Message Format Errors
-
-Ensure messages follow the MCP protocol format:
+From the [ReactFlowVoiceAgent example](https://github.com/WebMCP-org/examples/tree/main/ReactFlowVoiceAgent):
 
 ```typescript
+import { TabClientTransport } from '@mcp-b/transports';
+
+async function mcpConnect() {
+  // Create transport for same-origin communication
+  const transport = new TabClientTransport({
+    targetOrigin: window.location.origin
+  });
+  
+  // Use with MCP client
+  const client = new Client({
+    name: 'voice-agent',
+    version: '1.0.0'
+  }, {
+    capabilities: {}
+  });
+  
+  await client.connect(transport);
+  
+  // Now you can list and call tools
+  const tools = await client.listTools();
+  console.log('Available tools:', tools);
+}
+```
+
+### Chrome Extension Connector
+
+From the [extension-connector example](https://github.com/WebMCP-org/examples/tree/main/extension-connector):
+
+```typescript
+import { ExtensionClientTransport } from '@mcp-b/transports';
+
+const TARGET_EXTENSION_ID = 'your-mcp-extension-id';
+const PORT_NAME = 'mcp';
+
+async function connectToMcpExtension() {
+  // Create transport for extension
+  const transport = new ExtensionClientTransport({
+    extensionId: TARGET_EXTENSION_ID,
+    portName: PORT_NAME,
+  });
+  
+  const client = new Client({
+    name: 'extension-client',
+    version: '1.0.0'
+  }, {
+    capabilities: {}
+  });
+  
+  try {
+    await client.connect(transport);
+    console.log('Connected to MCP extension');
+    
+    // List available tools from extension
+    const tools = await client.listTools();
+    return { client, tools };
+  } catch (error) {
+    console.error('Failed to connect:', error);
+    throw error;
+  }
+}
+```
+
+## Configuration Options
+
+### TabServerTransport Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `allowedOrigins` | `string[]` | Yes | Array of allowed origins or `['*']` for all |
+
+### TabClientTransport Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `targetOrigin` | `string` | Yes | Origin of the target window (usually `window.location.origin`) |
+
+### ExtensionClientTransport Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `extensionId` | `string` | Yes | Chrome extension ID to connect to |
+| `portName` | `string` | No | Port name for connection (default: 'mcp') |
+
+## Usage with MCP SDK
+
+This package is designed to work with the official MCP SDK:
+
+```typescript
+import { TabServerTransport } from '@mcp-b/transports';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+// Or for clients:
+import { TabClientTransport } from '@mcp-b/transports';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+```
+
+## TypeScript Support
+
+Full TypeScript definitions are included. The transports implement the standard MCP transport interfaces:
+
+```typescript
+interface Transport {
+  // Implementation details handled by the transport
+  start(): Promise<void>;
+  send(message: JSONRPCMessage): Promise<void>;
+  close(): Promise<void>;
+}
+```
+
+## Browser Compatibility
+
+- Chrome/Chromium: Full support
+- Firefox: Tab transports supported, extension transport requires adaptation
+- Safari: Tab transports supported, no extension support
+- Edge: Full support (Chromium-based)
+
+## Security Considerations
+
+### CORS and Origins
+
+When using `TabServerTransport`, always specify explicit allowed origins in production:
+
+```typescript
+// ❌ Don't use wildcards in production
+const transport = new TabServerTransport({
+  allowedOrigins: ['*']
+});
+
+// ✅ Specify exact origins
+const transport = new TabServerTransport({
+  allowedOrigins: [
+    'https://myapp.com',
+    'https://app.myapp.com'
+  ]
+});
+```
+
+### Extension Permissions
+
+When using `ExtensionClientTransport`, ensure your extension manifest includes appropriate permissions:
+
+```json
 {
-  jsonrpc: "2.0",
-  method: "tools/call",
-  params: {
-    // method-specific parameters
-  },
-  id: "unique-request-id"
+  "permissions": ["tabs", "scripting"],
+  "host_permissions": ["<all_urls>"],
+  "externally_connectable": {
+    "matches": ["*://*.yourdomain.com/*"]
+  }
 }
 ```
 
 ## Related Packages
 
-- [@mcp-b/mcp-react-hooks](/packages/react-hooks) - React hooks for MCP
-- [@mcp-b/extension-tools](/packages/extension-tools) - Chrome Extension API tools
-- [@mcp-b/web-tools](https://www.npmjs.com/package/@mcp-b/web-tools) - Web-specific MCP tools
+- [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Official MCP SDK
+- [@mcp-b/web-tools](https://www.npmjs.com/package/@mcp-b/web-tools) - MCP tools for web APIs
+- [@mcp-b/mcp-react-hooks](/packages/react-hooks) - React hooks for MCP integration
 
 ## Resources
 
 - [GitHub Repository](https://github.com/WebMCP-org/npm-packages)
-- [Examples](https://github.com/WebMCP-org/examples)
+- [Working Examples](https://github.com/WebMCP-org/examples)
 - [MCP Protocol Specification](https://modelcontextprotocol.io)
+- [Chrome Extension Development](https://developer.chrome.com/docs/extensions)


### PR DESCRIPTION
## Summary
- Updated all NPM package documentation to accurately reflect the real implementation code
- Corrected API names, usage patterns, and examples based on actual source code analysis
- Aligned documentation with the WebMCP-org/examples repository

## Changes
- **@mcp-b/transports**: Fixed transport types (TabServerTransport, TabClientTransport, ExtensionClientTransport instead of generic BrowserTransport)
- **@mcp-b/mcp-react-hooks**: Corrected provider names (McpClientProvider, McpServerProvider, McpMemoryProvider) and hook APIs
- **@mcp-b/extension-tools**: Updated architecture description with BaseApiTools and 62+ Chrome API wrappers
- **@mcp-b/mcp-react-hook-form**: Documented three integration approaches with accurate examples from package source

## Test Plan
- [x] Verified all code examples against actual implementation in WebMCP-org/examples
- [x] Cross-referenced with npm-packages monorepo source code
- [x] Ensured all imports and API calls match real package exports
- [ ] Review documentation renders correctly in Mintlify preview

🤖 Generated with [Claude Code](https://claude.ai/code)