### PR TITLE
docs: remove twitter link, added discord and linkedin

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -127,6 +127,7 @@
   },
   "footerSocials": {
     "github": "https://github.com/WebMCP-org",
-    "x": "https://x.com/webmcp"
+    "discord": "https://discord.gg/ZnHG4csJRB",
+    "linkedin": "https://www.linkedin.com/company/mcp-b"
   }
 }


### PR DESCRIPTION
Removed the twitter link to https://x.com/webmcp that was in the footer and replaced with discord and linkedin.

https://x.com/webmcp is some random guy in Wisconsin.

Before
<img width="960" height="420" alt="chrome_AStgnEvMOa" src="https://github.com/user-attachments/assets/bc6ef96d-1c37-4d03-90ec-9a0628b9dac4" />

After
<img width="1920" height="839" alt="image" src="https://github.com/user-attachments/assets/71fdb04e-e4c4-46a1-9f18-1a0d8938a2a3" />

