### PR TITLE
docs: fixed links at end of examples

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -285,7 +285,7 @@ When creating your own MCP-B integration:
   <Card
     title="GitHub Discussions"
     icon="comment"
-    href="https://github.com/WebMCP-org/npm-packages/discussions"
+    href="https://github.com/MiguelsPizza/WebMCP/discussions"
   >
     Get help from the community
   </Card>
@@ -293,7 +293,7 @@ When creating your own MCP-B integration:
   <Card
     title="GitHub Issues"
     icon="github"
-    href="https://github.com/WebMCP-org/npm-packages/issues"
+    href="https://github.com/MiguelsPizza/WebMCP/issues"
   >
     Report bugs or request features
   </Card>


### PR DESCRIPTION
Fixed the 2 links on the bottom of the examples page.

<img width="1920" height="839" alt="image" src="https://github.com/user-attachments/assets/fa49f3d0-e0e3-468c-8aac-04935fbc0faa" />

GitHub Discussions was linking to https://github.com/WebMCP-org/npm-packages/discussions which is a 404. Changed to https://github.com/MiguelsPizza/WebMCP/discussions

GitHub Issues was linking to https://github.com/WebMCP-org/npm-packages/issues . Changed to https://github.com/MiguelsPizza/WebMCP/issues