### PR TITLE
Fix links

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -150,7 +150,7 @@ Perfect for adding MCP-B to existing websites without build tools:
   <Card
     title="Vue.js"
     icon="vuejs"
-    href="https://github.com/besian/mcp-b-vue-example"
+    href="https://github.com/bestian/vue-MCP-B-demo"
   >
     Vue 3 composition API integration by Besian
   </Card>
@@ -158,7 +158,7 @@ Perfect for adding MCP-B to existing websites without build tools:
   <Card
     title="Nuxt 3"
     icon="nuxt"
-    href="https://github.com/mikechao/mcp-b-nuxt-example"
+    href="https://github.com/mikechao/nuxt3-mcp-b-demo"
   >
     Full-stack Nuxt 3 with SSR support by Mike Chao
   </Card>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -89,7 +89,7 @@ graph LR
   <Card
     title="Discord"
     icon="discord"
-    href="https://discord.gg/your-discord"
+    href="https://discord.gg/ZnHG4csJRB"
   >
     Join our community for support and discussions
   </Card>

--- a/mint.json
+++ b/mint.json
@@ -37,7 +37,7 @@
   ],
   "topbarCtaButton": {
     "name": "Get Extension",
-    "url": "https://chrome.google.com/webstore/detail/mcp-b"
+    "url": "https://chromewebstore.google.com/detail/mcp-b-extension/daohopfhkdelnpemnhlekblhnikhdhfa"
   },
   "tabs": [
     {

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -135,7 +135,7 @@ await server.connect(new TabServerTransport({
   <Card
     title="Vanilla TypeScript"
     icon="js"
-    href="https://github.com/MiguelsPizza/mcp-b-examples/tree/main/vanilla-ts"
+    href="https://github.com/WebMCP-org/examples/tree/main/vanilla-ts"
   >
     Simple todo app with dynamic tool registration
   </Card>
@@ -143,7 +143,7 @@ await server.connect(new TabServerTransport({
   <Card
     title="React"
     icon="react"
-    href="https://github.com/MiguelsPizza/mcp-b-examples/tree/main/react"
+    href="https://github.com/WebMCP-org/examples/tree/main/reactFlowVoiceAgent"
   >
     Modern React app with hooks and state management
   </Card>
@@ -151,7 +151,7 @@ await server.connect(new TabServerTransport({
   <Card
     title="Vue"
     icon="vuejs"
-    href="https://github.com/besian/mcp-b-vue-example"
+    href="https://github.com/bestian/vue-MCP-B-demo"
   >
     Vue.js integration example by community
   </Card>
@@ -159,7 +159,7 @@ await server.connect(new TabServerTransport({
   <Card
     title="Nuxt 3"
     icon="nuxt"
-    href="https://github.com/mikechao/mcp-b-nuxt-example"
+    href="https://github.com/mikechao/nuxt3-mcp-b-demo"
   >
     Nuxt 3 example with SSR support
   </Card>


### PR DESCRIPTION
Fixed various links in the docs.

Get Extension in the top now points to https://chromewebstore.google.com/detail/mcp-b-extension/daohopfhkdelnpemnhlekblhnikhdhfa

Fixed links to examples.

Also fixed link to discord.