### PR TITLE
Update docs with webmcp.sh example and add AI features

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -3,13 +3,36 @@ title: 'Examples'
 description: 'Explore various WebMCP implementations and use cases'
 ---
 
+## Featured Example: WebMCP.sh
+
+**[webmcp.sh](https://webmcp.sh)** is a production-ready MCP playground showcasing best practices for WebMCP integration.
+
+<Card
+  title="webmcp.sh - MCP Playground"
+  icon="play"
+  href="https://github.com/WebMCP-org/webmcp-sh"
+>
+  Modern React app with comprehensive WebMCP integration, database tools, 3D graph visualization, and real-time MCP server connections
+</Card>
+
+**Why this example stands out:**
+- Production-grade React architecture with TypeScript
+- Real-world tool patterns: navigation, database operations, graph manipulation
+- Clean hook abstractions using `@mcp-b/react-webmcp`
+- Modern stack: React 19, TanStack Router, Drizzle ORM, Tailwind CSS
+- Demonstrates multiple tool types: read-only context, mutations, complex workflows
+
+**Key implementations to study:**
+- `useMCPNavigationTool.ts` - App navigation with route context
+- `useMCPDatabaseTools.ts` - Database CRUD operations
+- `useMCPGraphTools.ts` - Complex graph manipulation
+- `useMCPTool.ts` - Base tool pattern with validation and error handling
+
 <Info>
-  All examples are available in the [WebMCP Examples Repository](https://github.com/WebMCP-org/examples)
+  Additional examples available in the [WebMCP Examples Repository](https://github.com/WebMCP-org/examples)
 </Info>
 
-## Official Examples
-
-Our examples demonstrate WebMCP integration across different frameworks and use cases.
+## Additional Examples
 
 <CardGroup cols={2}>
   <Card
@@ -17,15 +40,7 @@ Our examples demonstrate WebMCP integration across different frameworks and use 
     icon="js"
     href="https://github.com/WebMCP-org/examples/tree/main/vanilla-ts"
   >
-    A simple todo app demonstrating core WebMCP concepts with navigator.modelContext
-  </Card>
-
-  <Card
-    title="React Flow Voice Agent"
-    icon="microphone"
-    href="https://github.com/WebMCP-org/examples/tree/main/reactFlowVoiceAgent"
-  >
-    Advanced React app with voice input, visual flow, and Gemini AI
+    Simple todo app demonstrating core concepts with navigator.modelContext
   </Card>
 
   <Card
@@ -37,6 +52,14 @@ Our examples demonstrate WebMCP integration across different frameworks and use 
   </Card>
 
   <Card
+    title="React Flow Voice Agent"
+    icon="microphone"
+    href="https://github.com/WebMCP-org/examples/tree/main/reactFlowVoiceAgent"
+  >
+    Advanced React app with voice input and visual flow
+  </Card>
+
+  <Card
     title="Login Flow"
     icon="lock"
     href="https://github.com/WebMCP-org/examples/tree/main/login"
@@ -45,122 +68,16 @@ Our examples demonstrate WebMCP integration across different frameworks and use 
   </Card>
 </CardGroup>
 
-## Vanilla TypeScript Example
+## Quick Reference
 
-The vanilla TypeScript example demonstrates:
-- Using `navigator.modelContext.provideContext()` for tool registration
-- Todo CRUD operations exposed as tools
-- Visual feedback for AI actions
-- State management without frameworks
+### Vanilla TypeScript
+Use `navigator.modelContext.provideContext()` to register tools. Perfect for adding WebMCP to existing sites without frameworks.
 
-### Key Features
+### React Hooks
+Use `useWebMCP()` from `@mcp-b/react-webmcp` for automatic lifecycle management, Zod validation, and execution state tracking.
 
-```typescript
-// Use the W3C Web Model Context API
-window.navigator.modelContext.provideContext({
-  tools: [
-    {
-      name: "add-todo",
-      description: "Add a new todo item",
-      inputSchema: {
-        type: "object",
-        properties: {
-          text: { type: "string", description: "Todo text" }
-        },
-        required: ["text"]
-      },
-      async execute({ text }) {
-        const todo = { id: Date.now(), text, done: false };
-        todos.push(todo);
-        render();
-        return {
-          content: [{
-            type: "text",
-            text: `Added todo: "${text}"`
-          }]
-        };
-      }
-    }
-  ]
-});
-```
-
-## React Example
-
-The React example showcases:
-- Integration with `@mcp-b/react-webmcp` hooks
-- Component-based tool organization
-- Modern React patterns with TypeScript
-- Real-time UI updates from tool calls
-
-### React Hook Integration
-
-```tsx
-import '@mcp-b/global';
-import { useWebMCP } from '@mcp-b/react-webmcp';
-import { z } from 'zod';
-
-function TodoApp() {
-  const [todos, setTodos] = useState([]);
-
-  // Register tool with React hook
-  useWebMCP({
-    name: 'add_todo',
-    description: 'Add a new todo',
-    inputSchema: {
-      text: z.string().describe('The todo text')
-    },
-    handler: async ({ text }) => {
-      setTodos([...todos, { id: Date.now(), text, done: false }]);
-      return { success: true };
-    },
-    formatOutput: (result) => `Todo added successfully!`
-  });
-
-  return <div>{/* Your UI */}</div>;
-}
-```
-
-## Script Tag Example
-
-Perfect for adding WebMCP to existing websites without build tools:
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-  <!-- IIFE version - bundles all dependencies, auto-initializes -->
-  <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
-</head>
-<body>
-  <div id="app">Hello World</div>
-
-  <script>
-    // window.navigator.modelContext is already available!
-    window.navigator.modelContext.provideContext({
-      tools: [
-        {
-          name: "get-message",
-          description: "Get the page message",
-          inputSchema: {
-            type: "object",
-            properties: {}
-          },
-          async execute() {
-            return {
-              content: [{
-                type: "text",
-                text: document.getElementById('app').innerText
-              }]
-            };
-          }
-        }
-      ]
-    });
-  </script>
-</body>
-</html>
-```
+### Script Tag Integration
+Add `@mcp-b/global` via unpkg for zero-config setup - no build tools required.
 
 ## Community Examples
 
@@ -184,151 +101,40 @@ Perfect for adding WebMCP to existing websites without build tools:
 
 ## Common Patterns
 
-### Dynamic Tool Registration (React)
+**Dynamic Tool Registration**: Tools in React components auto-register on mount and cleanup on unmount using `useWebMCP()`.
 
-```tsx
-import { useWebMCP } from '@mcp-b/react-webmcp';
+**Authentication-Aware Tools**: Conditionally expose tools based on user role or session state. Tools respect existing authentication via `credentials: 'same-origin'`.
 
-function MyComponent() {
-  const [isActive, setIsActive] = useState(false);
+**Visual Feedback**: Update UI state in tool handlers to provide real-time feedback for AI actions.
 
-  // Tool auto-registers when component mounts
-  // and auto-unregisters when it unmounts
-  useWebMCP({
-    name: 'component_action',
-    description: 'Component-specific action',
-    inputSchema: {},
-    handler: async () => {
-      // Your logic
-      return { success: true };
-    }
-  });
+## Running Examples
 
-  return <div>My Component</div>;
-}
-```
-
-### Authentication-Aware Tools
-
-```javascript
-// Only expose admin tools for admin users
-if (user.role === 'admin') {
-  window.navigator.modelContext.provideContext({
-    tools: [
-      {
-        name: "delete-all",
-        description: "Delete all items",
-        inputSchema: {
-          type: "object",
-          properties: {}
-        },
-        async execute() {
-          await fetch('/api/admin/delete-all', {
-            method: 'POST',
-            credentials: 'same-origin'
-          });
-          return {
-            content: [{ type: "text", text: "All items deleted" }]
-          };
-        }
-      }
-    ]
-  });
-}
-```
-
-### Visual Feedback
-
-```javascript
-window.navigator.modelContext.registerTool({
-  name: "highlight-element",
-  description: "Highlight an element on the page",
-  inputSchema: {
-    type: "object",
-    properties: {
-      selector: {
-        type: "string",
-        description: "CSS selector for the element"
-      }
-    },
-    required: ["selector"]
-  },
-  async execute({ selector }) {
-    const element = document.querySelector(selector);
-    if (element) {
-      element.style.backgroundColor = 'yellow';
-      setTimeout(() => {
-        element.style.backgroundColor = '';
-      }, 2000);
-      return {
-        content: [{ type: "text", text: `Highlighted ${selector}` }]
-      };
-    }
-    return {
-      content: [{ type: "text", text: "Element not found" }],
-      isError: true
-    };
-  }
-});
-```
-
-## Running the Examples
-
-### Quick Start
-
-1. Clone the examples repository:
 ```bash
 git clone https://github.com/WebMCP-org/examples.git
-cd examples
-```
-
-2. Choose an example:
-```bash
-cd vanilla-ts  # or react, script-tag
-```
-
-3. Install and run:
-```bash
+cd examples/vanilla-ts  # or any example
 pnpm install --ignore-workspace
 pnpm dev
 ```
 
-4. Open in Chrome with MCP-B extension installed
-
-### Testing Tools
-
-1. Open the MCP-B extension popup
-2. Navigate to the "Tools" tab
-3. See all available tools from the page
-4. Use the chat interface or inspector to call tools
+Open in Chrome with the MCP-B extension to test tools via the extension popup.
 
 ## Building Your Own
 
-When creating your own WebMCP integration:
-
 <Steps>
   <Step title="Choose your approach">
-    Use `@mcp-b/global` for simple sites or `@mcp-b/react-webmcp` for React apps
+    `@mcp-b/global` for vanilla sites, `@mcp-b/react-webmcp` for React
   </Step>
 
-  <Step title="Identify existing functionality">
-    List the actions users can take in your app
-  </Step>
-
-  <Step title="Wrap as tools">
-    Use `navigator.modelContext.provideContext()` or `useWebMCP()` hook
+  <Step title="Wrap existing functionality">
+    Expose your app's existing actions as tools - don't duplicate logic
   </Step>
 
   <Step title="Add validation">
-    Use JSON Schema or Zod schemas to validate tool inputs
+    Use Zod schemas (React) or JSON Schema (vanilla)
   </Step>
 
   <Step title="Test with extension">
-    Use the MCP-B extension to test your tools
-  </Step>
-
-  <Step title="Add feedback">
-    Provide visual feedback when tools are called
+    Use MCP-B extension to validate tools work correctly
   </Step>
 </Steps>
 

--- a/mint.json
+++ b/mint.json
@@ -130,5 +130,14 @@
     "github": "https://github.com/WebMCP-org",
     "discord": "https://discord.gg/ZnHG4csJRB",
     "linkedin": "https://www.linkedin.com/company/mcp-b"
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "perplexity"
+    ]
   }
 }

--- a/packages/react-webmcp.mdx
+++ b/packages/react-webmcp.mdx
@@ -5,180 +5,129 @@ sidebarTitle: "React WebMCP"
 icon: "react"
 ---
 
-Complete React hooks for the Model Context Protocol - register tools via `navigator.modelContext` and consume tools from MCP servers.
+React hooks for registering tools via `navigator.modelContext` and consuming tools from MCP servers.
 
 ## Installation
 
 ```bash
-pnpm add @mcp-b/react-webmcp zod
+pnpm add @mcp-b/react-webmcp @mcp-b/global zod
 ```
 
-For client functionality, you'll also need:
+For client functionality:
 ```bash
 pnpm add @mcp-b/transports @modelcontextprotocol/sdk
 ```
 
-## Prerequisites
-
-**For Provider Hooks:** Requires the global `navigator.modelContext` API. Install `@mcp-b/global` or use a browser that implements the Web Model Context API.
-
-**For Client Hooks:** Requires an MCP server to connect to (e.g., one created with `@mcp-b/global` or the Model Context Protocol SDK).
-
 ## Features
 
-### Provider Hooks (Registering Tools)
-- **Type-Safe**: Full TypeScript support with Zod schema validation
-- **State-Aware**: Track execution state (loading, success, error) for UI feedback
-- **React-Native**: Designed for React's lifecycle, including StrictMode compatibility
-- **Developer-Friendly**: Intuitive API with comprehensive examples
+**Provider Hooks (Registering Tools)**
+- Type-safe with Zod validation
+- Automatic lifecycle management (StrictMode compatible)
+- Execution state tracking for UI feedback
 
-### Client Hooks (Consuming Tools)
-- **MCP Client Provider**: Connect to MCP servers and consume their tools
-- **Real-time Updates**: Listen for tool list changes via MCP notifications
-- **Connection Management**: Automatic connection handling with reconnect support
-- **Type-Safe Tool Calls**: Full TypeScript support for client operations
+**Client Hooks (Consuming Tools)**
+- MCP server connection management
+- Real-time tool list updates
+- Automatic reconnection handling
 
 ---
 
-# Part 1: Provider API (Registering Tools)
+# Provider API (Registering Tools)
 
-Use these hooks to expose tools from your React app that AI agents can discover and call.
-
-## Quick Start - Provider
-
-### Basic Tool Registration
+## Basic Usage
 
 ```tsx
+import '@mcp-b/global';
 import { useWebMCP } from '@mcp-b/react-webmcp';
 import { z } from 'zod';
 
 function PostsPage() {
+  const [posts, setPosts] = useState([]);
+
   const likeTool = useWebMCP({
     name: 'posts_like',
-    description: 'Like a post by ID. Increments the like count.',
+    description: 'Like a post by ID',
     inputSchema: {
-      postId: z.string().uuid().describe('The post ID to like'),
+      postId: z.string().uuid()
     },
-    annotations: {
-      title: 'Like Post',
-      readOnlyHint: false,
-      idempotentHint: true,
-    },
-    handler: async (input) => {
-      await api.posts.like(input.postId);
-      return { success: true, postId: input.postId };
-    },
-    formatOutput: (result) => `Post ${result.postId} liked successfully!`,
+    handler: async ({ postId }) => {
+      await api.posts.like(postId);
+      return { success: true };
+    }
   });
 
   return (
     <div>
       {likeTool.state.isExecuting && <Spinner />}
-      {likeTool.state.error && <ErrorAlert error={likeTool.state.error} />}
-      {/* Your UI */}
+      {likeTool.state.error && <Error />}
     </div>
   );
 }
 ```
 
-### Context Tool
-
-Expose read-only context to AI:
+## Read-Only Context
 
 ```tsx
 import { useWebMCPContext } from '@mcp-b/react-webmcp';
 
-function PostDetailPage() {
+function PostDetail() {
   const { postId } = useParams();
-  const { data: post } = useQuery(['post', postId], () => fetchPost(postId));
+  const { data: post } = useQuery(['post', postId], fetchPost);
 
   useWebMCPContext(
     'context_current_post',
-    'Get the currently viewed post ID and metadata',
-    () => ({
-      postId,
-      title: post?.title,
-      author: post?.author,
-      tags: post?.tags,
-    })
+    'Get current post metadata',
+    () => ({ postId, title: post?.title, author: post?.author })
   );
 
-  return <div>{/* Post UI */}</div>;
+  return <div>{/* UI */}</div>;
 }
 ```
 
-## Provider API Reference
+## API Reference
 
-### `useWebMCP`
-
-Main hook for registering MCP tools with full control over behavior and state.
-
-```tsx
-function useWebMCP<
-  TInputSchema extends Record<string, z.ZodTypeAny>,
-  TOutput = string
->(config: WebMCPConfig<TInputSchema, TOutput>): WebMCPReturn<TOutput>
-```
-
-#### Configuration Options
+### `useWebMCP(config)`
 
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
-| `name` | `string` | ✓ | Unique tool identifier (e.g., 'posts_like') |
-| `description` | `string` | ✓ | Human-readable description for AI |
-| `inputSchema` | `Record<string, ZodType>` | - | Input validation using Zod schemas |
-| `outputSchema` | `Record<string, ZodType>` | - | Output validation (optional) |
-| `annotations` | `ToolAnnotations` | - | Metadata hints for the AI |
-| `elicitation` | `ElicitationConfig` | - | User confirmation settings |
-| `handler` | `(input) => Promise<TOutput>` | ✓ | Function that executes the tool |
+| `name` | `string` | ✓ | Unique tool identifier |
+| `description` | `string` | ✓ | Human-readable description |
+| `inputSchema` | `Record<string, ZodType>` | - | Zod validation schema |
+| `handler` | `(input) => Promise<TOutput>` | ✓ | Tool execution function |
+| `annotations` | `ToolAnnotations` | - | Metadata hints (readOnlyHint, idempotentHint, etc.) |
 | `formatOutput` | `(output) => string` | - | Custom output formatter |
-| `onError` | `(error, input) => void` | - | Error handler callback |
+| `onError` | `(error, input) => void` | - | Error handler |
 
-#### Return Value
-
+**Returns:**
 ```tsx
-interface WebMCPReturn<TOutput> {
+{
   state: {
-    isExecuting: boolean;      // Currently running
-    lastResult: TOutput | null; // Last successful result
-    error: Error | null;        // Last error
-    executionCount: number;     // Total executions
+    isExecuting: boolean;
+    lastResult: TOutput | null;
+    error: Error | null;
   };
-  execute: (input: unknown) => Promise<TOutput>; // Manual execution
-  reset: () => void;            // Reset state
+  execute: (input) => Promise<TOutput>;
+  reset: () => void;
 }
 ```
 
-### `useWebMCPContext`
+### `useWebMCPContext(name, description, getValue)`
 
-Simplified hook for read-only context exposure:
-
-```tsx
-function useWebMCPContext<T>(
-  name: string,
-  description: string,
-  getValue: () => T
-): WebMCPReturn<T>
-```
+Simplified hook for read-only context. Auto-registers and returns current state.
 
 ---
 
-# Part 2: Client API (Consuming Tools)
+# Client API (Consuming Tools)
 
-Use these hooks to connect to MCP servers and call their tools from your React app.
-
-## Quick Start - Client
-
-### Connecting to an MCP Server
+## Basic Usage
 
 ```tsx
 import { McpClientProvider, useMcpClient } from '@mcp-b/react-webmcp';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { TabClientTransport } from '@mcp-b/transports';
 
-// Create client and transport
 const client = new Client({ name: 'MyApp', version: '1.0.0' });
-const transport = new TabClientTransport('mcp', { clientInstanceId: 'my-app' });
+const transport = new TabClientTransport('mcp');
 
 function App() {
   return (
@@ -189,26 +138,21 @@ function App() {
 }
 
 function ToolConsumer() {
-  const { client, tools, isConnected, capabilities } = useMcpClient();
+  const { client, tools, isConnected } = useMcpClient();
 
-  const handleCallTool = async () => {
+  const callTool = async () => {
     const result = await client.callTool({
       name: 'posts_like',
       arguments: { postId: '123' }
     });
-    console.log('Result:', result.content[0].text);
+    console.log(result.content[0].text);
   };
 
   return (
     <div>
-      <p>Connected: {isConnected ? 'Yes' : 'No'}</p>
-      <p>Available Tools: {tools.length}</p>
-      <ul>
-        {tools.map(tool => (
-          <li key={tool.name}>{tool.name} - {tool.description}</li>
-        ))}
-      </ul>
-      <button onClick={handleCallTool} disabled={!isConnected}>
+      <p>Connected: {isConnected}</p>
+      <p>Tools: {tools.map(t => t.name).join(', ')}</p>
+      <button onClick={callTool} disabled={!isConnected}>
         Call Tool
       </button>
     </div>
@@ -216,237 +160,90 @@ function ToolConsumer() {
 }
 ```
 
-### Listening for Tool List Changes
-
-```tsx
-function ToolList() {
-  const { tools, isConnected, capabilities } = useMcpClient();
-
-  // Tools automatically update when server sends notifications
-  // if capabilities.tools.listChanged is true
-
-  return (
-    <div>
-      <h3>Tools ({tools.length})</h3>
-      {capabilities?.tools?.listChanged && (
-        <p>✓ Server supports real-time tool updates</p>
-      )}
-      {tools.map(tool => (
-        <div key={tool.name}>
-          <h4>{tool.name}</h4>
-          <p>{tool.description}</p>
-        </div>
-      ))}
-    </div>
-  );
-}
-```
-
-## Client API Reference
+## API Reference
 
 ### `McpClientProvider`
 
-Provider component that manages an MCP client connection.
-
 ```tsx
-interface McpClientProviderProps {
-  children: ReactNode;
-  client: Client;           // MCP client instance
-  transport: Transport;      // Transport for connection
-  opts?: RequestOptions;     // Optional connection options
-}
+<McpClientProvider client={client} transport={transport} opts={opts}>
+  {children}
+</McpClientProvider>
 ```
 
-#### Example Transports
+**Available Transports:**
+- `TabClientTransport` - Same-page MCP server
+- `ExtensionClientTransport` - Chrome extension server
+- `InMemoryTransport` - Testing
 
+### `useMcpClient()`
+
+**Returns:**
 ```tsx
-// Connect to same-page MCP server (via @mcp-b/global)
-import { TabClientTransport } from '@mcp-b/transports';
-const transport = new TabClientTransport('mcp', { clientInstanceId: 'my-app' });
-
-// Connect to Chrome extension MCP server
-import { ExtensionClientTransport } from '@mcp-b/transports';
-const transport = new ExtensionClientTransport({ portName: 'mcp' });
-
-// In-memory connection (for testing)
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-```
-
-### `useMcpClient`
-
-Hook to access the MCP client context. Must be used within `McpClientProvider`.
-
-```tsx
-interface McpClientContextValue {
-  client: Client;                        // MCP client instance
-  tools: Tool[];                         // Available tools from server
-  resources: Resource[];                 // Available resources
-  isConnected: boolean;                  // Connection status
-  isLoading: boolean;                    // Currently connecting
-  error: Error | null;                   // Connection error
-  capabilities: ServerCapabilities | null; // Server capabilities
-  reconnect: () => Promise<void>;        // Manual reconnection
-}
-```
-
-#### Calling Tools
-
-```tsx
-function MyComponent() {
-  const { client, isConnected } = useMcpClient();
-
-  const callTool = async () => {
-    if (!isConnected) return;
-
-    try {
-      const result = await client.callTool({
-        name: 'my_tool',
-        arguments: { foo: 'bar' }
-      });
-
-      // Extract text from result
-      const text = result.content
-        .filter(c => c.type === 'text')
-        .map(c => c.text)
-        .join('\n');
-
-      console.log(text);
-    } catch (error) {
-      console.error('Tool call failed:', error);
-    }
-  };
-
-  return <button onClick={callTool}>Call Tool</button>;
+{
+  client: Client;              // MCP SDK client
+  tools: Tool[];               // Available tools
+  resources: Resource[];       // Available resources
+  isConnected: boolean;        // Connection status
+  isLoading: boolean;          // Connecting
+  error: Error | null;         // Connection error
+  capabilities: ServerCapabilities | null;
+  reconnect: () => Promise<void>;
 }
 ```
 
 ---
 
-# Complete Example: Both Provider and Client
-
-This example shows a React app that both exposes tools AND consumes tools from an MCP server.
+# Complete Example
 
 ```tsx
-import '@mcp-b/global'; // Provides navigator.modelContext
+import '@mcp-b/global';
 import { McpClientProvider, useWebMCP, useMcpClient } from '@mcp-b/react-webmcp';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { TabClientTransport } from '@mcp-b/transports';
 import { z } from 'zod';
 
-// Create client to consume tools
 const client = new Client({ name: 'MyApp', version: '1.0.0' });
-const transport = new TabClientTransport('mcp', { clientInstanceId: 'my-app' });
+const transport = new TabClientTransport('mcp');
 
 function App() {
   return (
     <McpClientProvider client={client} transport={transport}>
-      <ToolProvider />
-      <ToolConsumer />
+      <Counter />
     </McpClientProvider>
   );
 }
 
-// Component that REGISTERS tools
-function ToolProvider() {
+function Counter() {
   const [count, setCount] = useState(0);
+  const { client, tools, isConnected } = useMcpClient();
 
-  // Expose a tool that increments the counter
+  // Register tool
   useWebMCP({
-    name: 'increment_counter',
-    description: 'Increment the counter',
-    inputSchema: {
-      amount: z.number().default(1)
-    },
+    name: 'increment',
+    description: 'Increment counter',
+    inputSchema: { amount: z.number().default(1) },
     handler: async ({ amount }) => {
       setCount(prev => prev + amount);
       return { newValue: count + amount };
     }
   });
 
-  return <div>Counter: {count}</div>;
-}
-
-// Component that CONSUMES tools
-function ToolConsumer() {
-  const { client, tools, isConnected } = useMcpClient();
-  const [result, setResult] = useState('');
-
-  const callIncrementTool = async () => {
+  // Call tool
+  const callTool = async () => {
     const res = await client.callTool({
-      name: 'increment_counter',
+      name: 'increment',
       arguments: { amount: 5 }
     });
-    setResult(res.content[0].text);
   };
 
   return (
     <div>
-      <p>Available Tools: {tools.map(t => t.name).join(', ')}</p>
-      <button onClick={callIncrementTool} disabled={!isConnected}>
-        Call increment_counter Tool
+      <p>Count: {count}</p>
+      <button onClick={callTool} disabled={!isConnected}>
+        Increment
       </button>
-      {result && <p>Result: {result}</p>}
     </div>
   );
-}
-```
-
----
-
-# Migration from @mcp-b/mcp-react-hooks
-
-If you're migrating from the deprecated `@mcp-b/mcp-react-hooks` package:
-
-## What Changed
-
-- **Server providers removed**: `McpServerProvider` and `McpMemoryProvider` are gone
-- **Everything in one package**: Both client and provider hooks are now in `@mcp-b/react-webmcp`
-- **Tool registration**: Use `useWebMCP` instead of server providers
-- **Client unchanged**: `McpClientProvider` and `useMcpClient` work the same way
-
-## Migration Guide
-
-### Before (mcp-react-hooks)
-
-```tsx
-import { McpClientProvider, useMcpClient } from '@mcp-b/mcp-react-hooks';
-import { McpServerProvider, useMcpServer } from '@mcp-b/mcp-react-hooks';
-```
-
-### After (react-webmcp)
-
-```tsx
-// Client hooks - same API
-import { McpClientProvider, useMcpClient } from '@mcp-b/react-webmcp';
-
-// For registering tools, use useWebMCP instead of server providers
-import { useWebMCP } from '@mcp-b/react-webmcp';
-```
-
-### Converting Server to Provider
-
-**Before:**
-```tsx
-function MyApp() {
-  const { registerTool } = useMcpServer();
-
-  useEffect(() => {
-    const tool = registerTool('my_tool', { description: '...' }, handler);
-    return () => tool.remove();
-  }, []);
-}
-```
-
-**After:**
-```tsx
-function MyApp() {
-  useWebMCP({
-    name: 'my_tool',
-    description: '...',
-    handler: handler
-  });
-  // Auto-registers and cleans up on unmount
 }
 ```
 
@@ -454,30 +251,35 @@ function MyApp() {
 
 # Best Practices
 
-### Tool Naming
-- Use verb-noun format: `posts_like`, `graph_navigate`, `table_filter`
-- Prefix with domain: `posts_`, `comments_`, `graph_`
-- Be specific and descriptive
+**Tool Naming**: Use verb-noun format with domain prefix: `posts_like`, `graph_navigate`, `table_filter`
 
-### Annotations
-- Always set `readOnlyHint` (true for queries, false for mutations)
-- Set `idempotentHint` (true if repeated calls are safe)
-- Set `destructiveHint` for delete/permanent operations
+**Annotations**: Set `readOnlyHint` (true for queries), `idempotentHint` (true if safe to retry), `destructiveHint` (for deletions)
 
-### Error Handling
-- Throw descriptive errors from tool handlers
-- Use `onError` callback for side effects (logging, toasts)
-- Handle connection errors in client components
+**Error Handling**: Throw descriptive errors. Use `onError` for logging/toasts. Handle connection errors in client components.
 
-### Performance
-- Tools automatically prevent duplicate registration in React StrictMode
-- Use `useWebMCPContext` for lightweight read-only data exposure
-- Client automatically manages reconnection and tool list updates
+**Performance**: Tools auto-dedupe in StrictMode. Use `useWebMCPContext` for lightweight read-only data.
 
-## License
+---
 
-MIT
+# Migration from @mcp-b/mcp-react-hooks
 
-## Contributing
+**Before:**
+```tsx
+const { registerTool } = useMcpServer();
+useEffect(() => {
+  const tool = registerTool('my_tool', { description: '...' }, handler);
+  return () => tool.remove();
+}, []);
+```
 
-See the [main repository](https://github.com/WebMCP-org/npm-packages) for contribution guidelines.
+**After:**
+```tsx
+useWebMCP({
+  name: 'my_tool',
+  description: '...',
+  handler
+});
+// Auto-registers and cleans up
+```
+
+Client hooks (`McpClientProvider`, `useMcpClient`) remain unchanged.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,106 +1,51 @@
 ---
 title: 'Quick Start'
-description: 'Get WebMCP running on your website in minutes'
+description: 'Get WebMCP running in minutes'
 ---
 
 <Info>
-  **Prerequisites**:
-  - Node.js 18+ (check with `node --version`)
-  - A website with JavaScript (vanilla, React, etc.)
-  - [MCP-B Chrome Extension](https://chrome.google.com/webstore/detail/mcp-b) installed for testing
+  **Prerequisites**: Node.js 18+, [MCP-B Chrome Extension](https://chrome.google.com/webstore/detail/mcp-b)
 </Info>
 
-## Installation Methods
-
-Choose your preferred installation method:
+## Installation
 
 <Tabs>
-  <Tab title="Script Tag (Easiest)">
-    ## Simple Script Integration
-
-    Add the W3C Web Model Context API to any website - no build tools required:
-
+  <Tab title="Script Tag">
     ```html
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <!-- IIFE version - bundles all dependencies, auto-initializes -->
-      <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
-    </head>
-    <body>
-      <h1>My AI-Powered App</h1>
-
-      <script>
-        // window.navigator.modelContext is already available!
-        window.navigator.modelContext.provideContext({
-          tools: [
-            {
-              name: "get-page-title",
-              description: "Get the current page title",
-              inputSchema: {
-                type: "object",
-                properties: {}
-              },
-              async execute() {
-                return {
-                  content: [{
-                    type: "text",
-                    text: document.title
-                  }]
-                };
-              }
-            }
-          ]
-        });
-      </script>
-    </body>
-    </html>
+    <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
+    <script>
+      navigator.modelContext.provideContext({
+        tools: [{
+          name: "get_page_title",
+          description: "Get current page title",
+          inputSchema: { type: "object", properties: {} },
+          async execute() {
+            return { content: [{ type: "text", text: document.title }] };
+          }
+        }]
+      });
+    </script>
     ```
   </Tab>
 
-  <Tab title="NPM Package">
-    ## Step 1: Install Dependencies
-
-    For apps using a bundler (Vite, Webpack, etc.):
-
-    ```bash npm
-    npm install @mcp-b/global
-    ```
-
-    ```bash pnpm
+  <Tab title="NPM">
+    ```bash
     pnpm add @mcp-b/global
     ```
-
-    ```bash yarn
-    yarn add @mcp-b/global
-    ```
-
-    ## Step 2: Import and Use
 
     ```javascript
     import '@mcp-b/global';
 
-    // window.navigator.modelContext is now available
-    window.navigator.modelContext.provideContext({
+    navigator.modelContext.provideContext({
       tools: [/* your tools */]
     });
     ```
   </Tab>
 
-  <Tab title="React Hooks">
-    ## Install React Package
-
-    For React applications with hooks:
-
-    ```bash npm
-    npm install @mcp-b/react-webmcp @mcp-b/global zod
-    ```
-
-    ```bash pnpm
+  <Tab title="React">
+    ```bash
     pnpm add @mcp-b/react-webmcp @mcp-b/global zod
     ```
-
-    ## Use in Components
 
     ```tsx
     import '@mcp-b/global';
@@ -110,12 +55,9 @@ Choose your preferred installation method:
     function MyComponent() {
       useWebMCP({
         name: 'my_tool',
-        description: 'Does something useful',
-        inputSchema: {
-          param: z.string()
-        },
+        description: 'Tool description',
+        inputSchema: { param: z.string() },
         handler: async ({ param }) => {
-          // Your logic here
           return { result: 'success' };
         }
       });
@@ -126,172 +68,106 @@ Choose your preferred installation method:
   </Tab>
 </Tabs>
 
-## Step 2: Register Your Tools
+## Real-World Example
 
-WebMCP uses the W3C Web Model Context API to expose tools to AI agents:
+Wrap existing application logic as tools:
 
 ```javascript
-window.navigator.modelContext.provideContext({
-  tools: [
-    {
-      name: "add-to-cart",
-      description: "Add an item to the shopping cart",
-      inputSchema: {
-        type: "object",
-        properties: {
-          productId: {
-            type: "string",
-            description: "The product ID to add"
-          },
-          quantity: {
-            type: "number",
-            description: "Quantity to add",
-            minimum: 1
-          }
-        },
-        required: ["productId", "quantity"]
+navigator.modelContext.provideContext({
+  tools: [{
+    name: "add_to_cart",
+    description: "Add item to shopping cart",
+    inputSchema: {
+      type: "object",
+      properties: {
+        productId: { type: "string" },
+        quantity: { type: "number", minimum: 1 }
       },
-      async execute({ productId, quantity }) {
-        // Your existing app logic here
-        const result = await fetch('/api/cart/add', {
-          method: 'POST',
-          credentials: 'same-origin',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ productId, quantity })
-        });
-
-        return {
-          content: [{
-            type: "text",
-            text: `Added ${quantity} of product ${productId} to cart`
-          }]
-        };
-      }
+      required: ["productId", "quantity"]
+    },
+    async execute({ productId, quantity }) {
+      await fetch('/api/cart/add', {
+        method: 'POST',
+        credentials: 'same-origin',
+        body: JSON.stringify({ productId, quantity })
+      });
+      return {
+        content: [{ type: "text", text: `Added ${quantity} items` }]
+      };
     }
-  ]
+  }]
 });
 ```
 
-## Step 3: Test Your Integration
+## Testing
 
-<Steps>
-  <Step title="Start your website">
-    Run your site via a dev server (e.g., `npm run dev`)
-  </Step>
+1. Run dev server: `pnpm dev`
+2. Open in Chrome with MCP-B extension
+3. Click extension icon → Tools tab
+4. Test tools via chat or inspector
 
-  <Step title="Open in Chrome">
-    Visit your page with the MCP-B extension installed
-  </Step>
-
-  <Step title="Open extension popup">
-    Click the MCP-B icon in your toolbar
-  </Step>
-
-  <Step title="Test your tools">
-    - Go to the "Tools" tab to see exposed tools
-    - Use the chat interface to interact with AI
-    - Or manually invoke tools via the inspector
-  </Step>
-</Steps>
-
-## Framework Examples
+## Examples
 
 <CardGroup cols={2}>
+  <Card
+    title="webmcp.sh"
+    icon="play"
+    href="https://github.com/WebMCP-org/webmcp-sh"
+  >
+    Production-ready React app with database, navigation, and graph tools
+  </Card>
+
   <Card
     title="Vanilla TypeScript"
     icon="js"
     href="https://github.com/WebMCP-org/examples/tree/main/vanilla-ts"
   >
-    Simple todo app with dynamic tool registration
+    Todo app with dynamic tool registration
   </Card>
 
   <Card
-    title="React"
-    icon="react"
-    href="https://github.com/WebMCP-org/examples/tree/main/reactFlowVoiceAgent"
+    title="Script Tag"
+    icon="code"
+    href="https://github.com/WebMCP-org/examples/tree/main/script-tag"
   >
-    Modern React app with hooks and state management
+    Zero-config setup with no build tools
   </Card>
 
   <Card
-    title="Vue"
-    icon="vuejs"
-    href="https://github.com/bestian/vue-MCP-B-demo"
+    title="More Examples"
+    icon="folder"
+    href="/examples"
   >
-    Vue.js integration example by community
-  </Card>
-
-  <Card
-    title="Nuxt 3"
-    icon="nuxt"
-    href="https://github.com/mikechao/nuxt3-mcp-b-demo"
-  >
-    Nuxt 3 example with SSR support
+    Vue, Nuxt, React Flow, and community examples
   </Card>
 </CardGroup>
 
 ## Best Practices
 
-<AccordionGroup>
-  <Accordion title="Security Considerations">
-    - Only expose tools you'd allow via UI
-    - Validate all tool inputs with JSON Schema or Zod
-    - Tools run in your page's context with same permissions
-    - Consider rate limiting for expensive operations
-  </Accordion>
+**Security**: Only expose tools allowed via UI. Validate inputs. Tools run with same permissions as your page.
 
-  <Accordion title="Tool Design">
-    - Wrap existing app logic, don't duplicate it
-    - Use descriptive tool names and descriptions
-    - Add visual feedback for AI actions (notifications, highlights)
-    - Keep tools focused on single actions
-  </Accordion>
+**Tool Design**: Wrap existing logic, don't duplicate. Use descriptive names. Add visual feedback.
 
-  <Accordion title="Authentication">
-    - Use `credentials: 'same-origin'` for authenticated API calls
-    - Tools respect existing session cookies
-    - Scope admin tools to admin pages only
-  </Accordion>
+**Authentication**: Use `credentials: 'same-origin'`. Tools respect session cookies.
 
-  <Accordion title="Performance">
-    - Use `registerTool()` for component-scoped tools in React
-    - Use tool caching for expensive operations
-    - Register/unregister tools dynamically based on page state
-  </Accordion>
-</AccordionGroup>
+**Performance**: In React, tools auto-register/cleanup. Register dynamically based on page state.
 
-## What's Next?
+## Next Steps
 
-<CardGroup>
-  <Card
-    title="Explore Examples"
-    icon="code"
-    href="/examples"
-  >
-    See complete working examples for different use cases
+<CardGroup cols={2}>
+  <Card title="Examples" icon="code" href="/examples">
+    Complete working examples and patterns
   </Card>
 
-  <Card
-    title="NPM Packages"
-    icon="box"
-    href="/packages/global"
-  >
-    Learn about @mcp-b/global, transports, and React hooks
+  <Card title="React Hooks" icon="react" href="/packages/react-webmcp">
+    @mcp-b/react-webmcp package documentation
   </Card>
 
-  <Card
-    title="Advanced Usage"
-    icon="gear"
-    href="/advanced"
-  >
-    Learn about dynamic tools, Chrome extensions, and more
+  <Card title="Packages" icon="box" href="/packages/global">
+    All available NPM packages
   </Card>
 
-  <Card
-    title="Troubleshooting"
-    icon="wrench"
-    href="/troubleshooting"
-  >
-    Common issues and solutions
+  <Card title="Advanced" icon="gear" href="/advanced">
+    Chrome extensions, transports, and more
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Featured webmcp.sh as the primary production-ready example
- Added Mintlify contextual menu with AI integration (copy, view, ChatGPT, Claude, Perplexity)
- Condensed documentation for better information density
- Updated examples.mdx, quickstart.mdx, and react-webmcp.mdx
- Removed verbose code examples in favor of concise real-world patterns
- Referenced latest npm-packages implementations

## Changes
- **examples.mdx**: Featured webmcp.sh at top, condensed verbose sections
- **quickstart.mdx**: Streamlined getting started guide
- **packages/react-webmcp.mdx**: More concise React hooks documentation
- **mint.json**: Added contextual menu configuration for AI tools

## AI Features Added
The contextual menu now enables users to:
- Copy pages as Markdown for AI context
- View pages in Markdown format
- Open in ChatGPT, Claude, or Perplexity with page context pre-loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)