### PR TITLE
fix: update license from AGPL-3.0 to MIT

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -84,9 +84,9 @@ WebMCP implements the `navigator.modelContext` web standard, letting you expose 
   <Card
     title="License"
     icon="scale-balanced"
-    href="https://github.com/MiguelsPizza/WebMCP/blob/main/LICENSE"
+    href="https://github.com/WebMCP-org/npm-packages/blob/main/LICENSE"
   >
-    AGPL-3.0 License
+    MIT License
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Corrected license information in introduction to reflect MIT license. Also updated license URL to point to WebMCP-org repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)