### PR TITLE
Update WebMCP Documentation for Clarity

### DIFF
--- a/concepts.mdx
+++ b/concepts.mdx
@@ -10,17 +10,27 @@ icon: 'diagram-project'
 
 ## What is WebMCP?
 
-WebMCP is an ecosystem that implements the **W3C Web Model Context API**, bringing the Model Context Protocol (MCP) to web browsers. It allows websites to expose their functionality as structured tools that AI agents can discover and use.
+**WebMCP** (Web Model Context Protocol) is a **W3C web standard** currently being incubated that defines how websites expose structured tools to AI agents through the browser's `navigator.modelContext` API.
+
+### Relationship to MCP
+
+WebMCP is inspired by Anthropic's [Model Context Protocol (MCP)](https://modelcontextprotocol.io) but adapted specifically for web browsers. While WebMCP shares similar concepts with MCP (tools, resources, structured communication), it is evolving as an independent web standard with its own specification path.
+
+**MCP-B packages** provide:
+1. **W3C API polyfill** - Implements `navigator.modelContext` for browsers that don't yet support it natively
+2. **Translation layer** - Bridges between WebMCP and official MCP, allowing tools declared in either format to work with both protocols
+
+This means you can build with WebMCP's web-native API while maintaining compatibility with the broader MCP ecosystem.
 
 ## Key Components
 
 <CardGroup cols={2}>
   <Card title="W3C Web Model Context API" icon="globe">
-    Standard browser API (`navigator.modelContext`) for registering tools
+    Standard browser API (`navigator.modelContext`) for registering tools - the WebMCP specification
   </Card>
 
-  <Card title="MCP Bridge" icon="arrows-left-right">
-    Automatic bridging between Web API and MCP protocol
+  <Card title="MCP-B Polyfill & Bridge" icon="arrows-left-right">
+    Implements navigator.modelContext for current browsers and translates between WebMCP and MCP protocols
   </Card>
 
   <Card title="Transport Layer" icon="tower-broadcast">
@@ -28,7 +38,7 @@ WebMCP is an ecosystem that implements the **W3C Web Model Context API**, bringi
   </Card>
 
   <Card title="MCP-B Extension" icon="puzzle-piece">
-    Browser extension that connects AI agents to website tools
+    Development and testing tool that collects WebMCP servers from tabs and supports userscript injection
   </Card>
 </CardGroup>
 
@@ -500,6 +510,20 @@ const schema = {
 - ✅ Show loading states in UI
 - ❌ Don't block the main thread
 - ❌ Avoid heavy computations in handlers
+
+## External Standards & Specifications
+
+Learn more about the underlying protocols:
+
+<CardGroup cols={2}>
+  <Card title="MCP Specification" icon="book" href="https://modelcontextprotocol.io">
+    Official Model Context Protocol documentation from Anthropic
+  </Card>
+
+  <Card title="MCP SDK" icon="code" href="https://github.com/modelcontextprotocol/typescript-sdk">
+    TypeScript SDK for building MCP servers and clients
+  </Card>
+</CardGroup>
 
 ## Related Resources
 

--- a/docs.json
+++ b/docs.json
@@ -7,7 +7,7 @@
     "light": "/logo/mcp-b-logo.png"
   },
   "favicon": "/favicon.ico",
-  "description": "WebMCP - Turn your website's JavaScript functions into AI-accessible tools. Make your web app work with Claude, ChatGPT, and custom AI agents.",
+  "description": "WebMCP - W3C standard for making websites AI-accessible. Turn your JavaScript functions into tools that work with Claude, ChatGPT, and custom AI agents via navigator.modelContext.",
   "colors": {
     "primary": "#1F5EFF",
     "light": "#4B7BFF",
@@ -155,7 +155,7 @@
   "seo": {
     "indexing": "all",
     "metatags": {
-      "description": "WebMCP - Turn your website's JavaScript functions into AI-accessible tools. Make your web app work with Claude, ChatGPT, and custom AI agents.",
+      "description": "WebMCP - W3C standard for making websites AI-accessible. Turn your JavaScript functions into tools that work with Claude, ChatGPT, and custom AI agents via navigator.modelContext.",
       "keywords": "MCP, Model Context Protocol, WebMCP, AI agents, web tools, browser extension, tab transport, JavaScript SDK",
       "author": "WebMCP Team",
       "robots": "index, follow",
@@ -164,14 +164,14 @@
       "og:type": "website",
       "og:url": "https://docs.mcp-b.ai",
       "og:image": "https://docs.mcp-b.ai/logo/social-card.png",
-      "og:description": "Turn your website's JavaScript functions into AI-accessible tools. WebMCP implements the W3C Web Model Context API, making your web app compatible with Claude, ChatGPT, and custom AI agents.",
+      "og:description": "W3C standard for making websites AI-accessible. WebMCP defines the Web Model Context API (navigator.modelContext), enabling your site to work with Claude, ChatGPT, and custom AI agents.",
       "og:site_name": "WebMCP Documentation",
       "og:locale": "en_US",
       "twitter:card": "summary_large_image",
       "twitter:site": "@webmcp",
       "twitter:creator": "@webmcp",
       "twitter:title": "WebMCP Documentation - AI-Powered Web Tools",
-      "twitter:description": "Turn your website's JavaScript functions into AI-accessible tools. WebMCP implements the W3C Web Model Context API for Claude, ChatGPT, and custom AI agents.",
+      "twitter:description": "W3C standard for making websites AI-accessible. WebMCP defines the Web Model Context API for Claude, ChatGPT, and custom AI agents.",
       "twitter:image": "https://docs.mcp-b.ai/logo/social-card.png",
       "twitter:image:alt": "WebMCP Documentation - Model Context Protocol for the Web",
       "article:published_time": "2024-01-01T00:00:00+00:00",

--- a/extension/index.mdx
+++ b/extension/index.mdx
@@ -6,7 +6,7 @@ icon: puzzle-piece
 
 # MCP-B Extension
 
-The MCP-B browser extension brings the power of Model Context Protocol to your web browser. Create custom userscripts, build AI-accessible tools, and automate web interactions - all with the help of specialized AI agents.
+The MCP-B browser extension is a development and testing tool for WebMCP servers. It collects WebMCP tools from all your open tabs, lets you inject custom servers via userscript, and includes specialized AI agents to help you build and test web-based tools.
 
 <Card
   title="Install MCP-B Extension"

--- a/glossary.mdx
+++ b/glossary.mdx
@@ -109,17 +109,33 @@ JSON Schema or Zod schema defining the parameters a tool accepts. Used for valid
 ## M
 
 ### MCP (Model Context Protocol)
-An open standard protocol for connecting AI systems with data sources and tools. Developed by Anthropic, it standardizes how AI agents discover and interact with external capabilities.
+An open standard protocol developed by Anthropic for connecting AI systems with data sources and tools. MCP standardizes how AI agents discover and interact with external capabilities. WebMCP is inspired by MCP but adapted specifically for web browsers as a W3C standard.
 
 **Specification:** https://modelcontextprotocol.io
+**Documentation:** https://modelcontextprotocol.io/docs
+**GitHub:** https://github.com/modelcontextprotocol
+
+### MCP-B
+The reference implementation and tooling ecosystem for the WebMCP standard, originally created as the first browser port of MCP. MCP-B packages serve two key purposes:
+
+1. **Polyfill** the W3C WebMCP API for current browsers
+2. **Translation layer** between WebMCP and official MCP protocols
+
+The name "MCP-B" refers to both the package ecosystem (`@mcp-b/*`) and the browser extension.
 
 ### MCP-B Extension
-The official browser extension that connects AI agents to website tools. Includes specialized agents for userscript creation, browsing, and chat. Part of the WebMCP ecosystem.
+Browser extension for building, testing, and using WebMCP servers. Key features:
+- Collects WebMCP servers from all open tabs
+- Userscript injection for custom tool development
+- Specialized agents (browsing, userscript, chat)
 
 **Download:** [Chrome Web Store](https://chromewebstore.google.com/detail/mcp-b-extension/daohopfhkdelnpemnhlekblhnikhdhfa)
 
 ### MCP Bridge
-The internal component in `@mcp-b/global` that automatically converts between the Web Model Context API and the Model Context Protocol.
+The internal component in `@mcp-b/global` that serves as both a polyfill and translation layer:
+- Implements the WebMCP `navigator.modelContext` API
+- Translates between WebMCP and MCP protocols
+- Allows tools declared in either format to work with both standards
 
 **Location:** Created automatically when importing `@mcp-b/global`
 
@@ -295,12 +311,16 @@ Custom JavaScript code that modifies web page behavior or appearance. The MCP-B 
 International standards organization for the web. The Web Model Context API is a proposed W3C standard.
 
 ### Web Model Context API
-Proposed web standard (currently polyfilled) for exposing website functionality to AI agents via `navigator.modelContext`.
+See [WebMCP](#webmcp)
 
-**Specification:** https://github.com/webmachinelearning/webmcp
+### WebMCP (Web Model Context Protocol)
+A **W3C web standard** (currently being incubated) that defines how websites expose structured tools to AI agents through the browser's `navigator.modelContext` API.
 
-### WebMCP
-The ecosystem of packages and tools that bring MCP to web browsers, including the polyfill, transports, React hooks, and browser extension.
+While inspired by Anthropic's Model Context Protocol, WebMCP is evolving as an independent web-native standard. The MCP-B packages provide the reference implementation, polyfill, and translation layer.
+
+**Relationship to MCP:** WebMCP shares similar concepts (tools, resources, structured communication) but is diverging as a web-specific standard with its own evolution path.
+
+**Specification:** https://github.com/webmachinelearning/webmcp (W3C incubation)
 
 ## Z
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'WebMCP Documentation'
-description: 'Bringing the power of MCP to the web - Enable AI agents to interact with your website through structured tools'
+description: 'W3C standard for making websites AI-accessible - Enable AI agents to interact with your website through structured tools via navigator.modelContext'
 ---
 
 ## Welcome to WebMCP
@@ -13,16 +13,18 @@ AI assistants are great at conversation, but they can't reliably interact with y
 
 ### The Solution
 
-**WebMCP** is an ecosystem that implements the **W3C Web Model Context API** - a standards-track proposal that lets websites expose structured tools to AI agents through `navigator.modelContext`.
+**WebMCP** is a W3C web standard (currently being incubated) that lets websites expose structured tools to AI agents through the `navigator.modelContext` API.
 
 With WebMCP, your existing JavaScript functions become discoverable tools. AI assistants can then help users by directly calling your website's functionality - all while respecting authentication and permissions.
 
 ### Key Terms
 
-- **WebMCP**: The ecosystem of packages and tools for web-based Model Context Protocol
-- **`navigator.modelContext`**: The W3C standard API (polyfilled by `@mcp-b/global`)
-- **MCP-B Extension**: The browser extension that connects AI agents to website tools
-- **MCP**: Model Context Protocol - Anthropic's open standard for AI-tool integration
+- **WebMCP**: The W3C Web Model Context API standard - defines how websites expose tools to AI agents in browsers. While related to MCP, WebMCP will diverge as a web-native standard with its own evolution path.
+- **MCP (Model Context Protocol)**: Anthropic's [open standard](https://modelcontextprotocol.io) for connecting AI systems to external tools and data sources. The original protocol that inspired WebMCP.
+- **MCP-B**: The reference implementation and tooling ecosystem for WebMCP. These packages serve dual purposes:
+  1. **Polyfill** the W3C WebMCP API (`navigator.modelContext`) for current browsers
+  2. **Translation layer** between WebMCP and official MCP, so tools declared in either format work with both protocols
+- **MCP-B Extension**: Browser extension for building, testing, and using WebMCP servers. Collects tools from all open tabs and lets you inject custom servers via userscript.
 
 <CardGroup cols={2}>
   <Card
@@ -229,6 +231,23 @@ That's it! Your tools are now discoverable by AI agents.
     Use our [NPM packages](/packages/global) to create custom tools
   </Step>
 </Steps>
+
+## Understanding the Standards
+
+WebMCP builds on the Model Context Protocol (MCP), adapting it for the web platform:
+
+<CardGroup cols={2}>
+  <Card title="MCP Documentation" icon="book" href="https://modelcontextprotocol.io">
+    Learn about the original Model Context Protocol specification
+  </Card>
+  <Card title="MCP GitHub" icon="github" href="https://github.com/modelcontextprotocol">
+    Explore Anthropic's official MCP repositories and SDK
+  </Card>
+</CardGroup>
+
+<Info>
+**New to MCP?** The Model Context Protocol is Anthropic's open standard for connecting AI assistants to external tools and data. WebMCP is the W3C's web-native adaptation of these concepts, with MCP-B packages providing both the polyfill and translation layer between the two standards.
+</Info>
 
 ## Related Resources
 


### PR DESCRIPTION
…tation

Update documentation messaging to accurately position:
- WebMCP as W3C web standard (being incubated)
- MCP-B as reference implementation and tooling ecosystem
- Dual role: W3C API polyfill + MCP translation layer
- WebMCP diverging from MCP as independent web standard

Changes:
- introduction.mdx: Updated key terms and added MCP resources section
- concepts.mdx: Added relationship to MCP section with clear explanations
- glossary.mdx: Enhanced definitions for WebMCP, MCP, MCP-B, and MCP Bridge
- extension/index.mdx: Clarified extension purpose as dev/testing tool
- docs.json: Updated SEO descriptions to emphasize W3C standard

Added proper links to official MCP documentation throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)