### PR TITLE
Document mcp-ui with WebMCP and iframe transports

### DIFF
--- a/mcpui-webmcp-integration.mdx
+++ b/mcpui-webmcp-integration.mdx
@@ -5,7 +5,7 @@ icon: 'heart'
 ---
 
 <Note>
-**Novel Integration Pattern**: MCP-UI serves HTML/iframes that contain WebMCP servers. When the parent has a tab transport client, it **automatically discovers** all tools inside the iframe - no manual bridging needed!
+**Novel Integration Pattern**: MCP-UI serves HTML/iframes that contain MCP servers. The parent page can connect using either **IframeParentTransport** (for cross-origin) or **TabClientTransport** (for same-origin), and it **automatically discovers** all tools inside the iframe - no manual bridging needed!
 </Note>
 
 ## The Simple Idea
@@ -15,14 +15,14 @@ Here's the entire concept:
 ```mermaid
 graph TB
     subgraph "MCP-UI Server"
-        A[Returns UIResource<br/>HTML with WebMCP tools]
+        A[Returns UIResource<br/>HTML with MCP server]
     end
 
     subgraph "Parent App Host"
-        B[Has: TabClientTransport]
+        B[Has: IframeParentTransport<br/>or TabClientTransport]
 
         subgraph "Iframe"
-            C[HTML UI<br/>+<br/>navigator.modelContext tools<br/>✨ Automatically discovered]
+            C[HTML UI<br/>+<br/>MCP Server with tools<br/>✨ Automatically discovered]
         end
 
         B -.->|connects to| C
@@ -35,7 +35,7 @@ graph TB
     style C fill:#50C878,color:#fff
 ```
 
-**That's it.** The tab transport automatically picks up any WebMCP tools registered inside the iframe using `navigator.modelContext.registerTool()`.
+**That's it.** The parent transport (either `IframeParentTransport` for cross-origin or `TabClientTransport` for same-origin) automatically discovers and connects to the MCP server inside the iframe.
 
 ## How It Works
 
@@ -225,6 +225,222 @@ Iframe: Returns registered tools
    ↓ (Tab Transport)
 Parent: Receives tool list
 ```
+
+## Using Iframe Transports for Cross-Origin
+
+When your MCP-UI iframe is hosted on a different origin than the parent page, use `IframeParentTransport` and `IframeChildTransport` instead of Tab transports. These provide proper cross-origin security and handle iframe loading timing automatically.
+
+### Step 1: MCP-UI Server Returns HTML with IframeChildTransport
+
+```typescript
+import { createUIResource } from '@mcp-ui/server';
+
+// MCP server returns a UIResource with iframe transport
+const uiResource = createUIResource({
+  uri: 'ui://shopping/cart',
+  content: {
+    type: 'rawHtml',
+    htmlString: `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <script type="module">
+            import { IframeChildTransport } from 'https://esm.sh/@mcp-b/transports';
+            import { Server } from 'https://esm.sh/@modelcontextprotocol/sdk/server/index.js';
+
+            // Create MCP server
+            const server = new Server(
+              { name: 'ShoppingCart', version: '1.0.0' },
+              { capabilities: { tools: {} } }
+            );
+
+            // Register tool handlers
+            server.setRequestHandler('tools/list', async () => {
+              return {
+                tools: [
+                  {
+                    name: 'add_to_cart',
+                    description: 'Add product to shopping cart',
+                    inputSchema: {
+                      type: 'object',
+                      properties: {
+                        productId: { type: 'string' },
+                        quantity: { type: 'number' }
+                      },
+                      required: ['productId', 'quantity']
+                    }
+                  },
+                  {
+                    name: 'get_cart_contents',
+                    description: 'Get current shopping cart contents',
+                    inputSchema: { type: 'object', properties: {} }
+                  }
+                ]
+              };
+            });
+
+            server.setRequestHandler('tools/call', async (request) => {
+              const { name, arguments: args } = request.params;
+
+              if (name === 'add_to_cart') {
+                const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+                cart.push({ productId: args.productId, quantity: args.quantity });
+                localStorage.setItem('cart', JSON.stringify(cart));
+
+                // Update UI
+                document.getElementById('cart-items').innerHTML =
+                  cart.map(item => \`<div>\${item.productId} x\${item.quantity}</div>\`).join('');
+
+                return {
+                  content: [{
+                    type: 'text',
+                    text: JSON.stringify({ success: true, cartSize: cart.length })
+                  }]
+                };
+              }
+
+              if (name === 'get_cart_contents') {
+                const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+                return {
+                  content: [{
+                    type: 'text',
+                    text: JSON.stringify({ items: cart, total: cart.length })
+                  }]
+                };
+              }
+
+              throw new Error(\`Unknown tool: \${name}\`);
+            });
+
+            // Connect with iframe child transport
+            const transport = new IframeChildTransport({
+              allowedOrigins: ['https://your-app.com'], // Parent origin
+            });
+
+            await server.connect(transport);
+          </script>
+        </head>
+        <body>
+          <h1>Shopping Cart</h1>
+          <div id="cart-items">Cart is empty</div>
+        </body>
+      </html>
+    `
+  }
+});
+```
+
+### Step 2: Parent Uses IframeParentTransport
+
+```typescript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { IframeParentTransport } from '@mcp-b/transports';
+import { UIResourceRenderer } from '@mcp-ui/client';
+
+function ShoppingApp({ mcpResponse }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [tools, setTools] = useState([]);
+  const [client, setClient] = useState<Client | null>(null);
+
+  useEffect(() => {
+    async function connectToIframe() {
+      if (!iframeRef.current) return;
+
+      // Create MCP client with iframe parent transport
+      const mcpClient = new Client(
+        { name: 'host-app', version: '1.0.0' },
+        { capabilities: {} }
+      );
+
+      const transport = new IframeParentTransport({
+        iframe: iframeRef.current,
+        targetOrigin: 'https://iframe-origin.com' // Iframe's origin
+      });
+
+      await mcpClient.connect(transport);
+
+      // ✨ Automatically discover tools from iframe
+      const { tools } = await mcpClient.listTools();
+      setTools(tools);
+      setClient(mcpClient);
+
+      console.log('Found tools:', tools);
+    }
+
+    if (iframeRef.current) {
+      // Wait for iframe to load
+      iframeRef.current.addEventListener('load', () => {
+        // Small delay to ensure iframe is fully initialized
+        setTimeout(connectToIframe, 300);
+      });
+    }
+
+    return () => {
+      client?.close();
+    };
+  }, []);
+
+  const handleAddToCart = async (productId: string) => {
+    if (!client) return;
+
+    const result = await client.callTool({
+      name: 'add_to_cart',
+      arguments: { productId, quantity: 1 }
+    });
+
+    console.log('Added to cart:', result);
+  };
+
+  return (
+    <div>
+      <h2>Shopping Cart</h2>
+      <p>Discovered {tools.length} tools from iframe</p>
+
+      <button onClick={() => handleAddToCart('laptop-123')}>
+        Add Laptop to Cart
+      </button>
+
+      <UIResourceRenderer
+        ref={iframeRef}
+        resource={mcpResponse.content[0].resource}
+      />
+    </div>
+  );
+}
+```
+
+### Benefits of Iframe Transports
+
+<CardGroup cols={2}>
+  <Card title="Cross-Origin Security" icon="shield">
+    Proper origin validation on both parent and child sides
+  </Card>
+
+  <Card title="Automatic Ready Handshake" icon="handshake">
+    Built-in retry mechanism handles iframe loading timing
+  </Card>
+
+  <Card title="Isolated Communication" icon="diagram-project">
+    Dedicated channel prevents interference with other postMessage usage
+  </Card>
+
+  <Card title="Production Ready" icon="check-circle">
+    Designed specifically for parent-child iframe scenarios
+  </Card>
+</CardGroup>
+
+## Choosing Between Tab and Iframe Transports
+
+**Use Tab Transports when:**
+- Parent and iframe are on the same origin
+- You want automatic server discovery
+- You're working with multiple servers in the same context
+
+**Use Iframe Transports when:**
+- Parent and iframe are on different origins
+- You need explicit parent-child communication
+- You want dedicated channel isolation
+- You need robust iframe loading handling
 
 ## More Examples
 
@@ -418,12 +634,15 @@ async function addToCart(productId) {
 
 <Warning>
 **Important**:
-- Use specific `targetOrigin` in production (not `'*'`)
+- Use specific `targetOrigin` in production (never `'*'`)
+- Configure `allowedOrigins` to whitelist only trusted domains
 - Validate all tool inputs in both iframe and parent
 - Be aware the iframe can register any tools it wants
 - Don't expose sensitive operations without authentication checks
+- For cross-origin scenarios, always use Iframe transports over Tab transports
 </Warning>
 
+**Tab Transport (same-origin):**
 ```typescript
 // Good - specific origin
 const transport = new TabClientTransport({
@@ -433,6 +652,25 @@ const transport = new TabClientTransport({
 // Bad - allows any origin (dev only!)
 const transport = new TabClientTransport({
   targetOrigin: '*'
+});
+```
+
+**Iframe Transport (cross-origin):**
+```typescript
+// Parent side - Good
+const transport = new IframeParentTransport({
+  iframe: iframeElement,
+  targetOrigin: 'https://iframe-app.com' // Specific iframe origin
+});
+
+// Child side - Good
+const transport = new IframeChildTransport({
+  allowedOrigins: ['https://parent-app.com'] // Whitelist parent origins
+});
+
+// Bad - allows any origin (never use in production!)
+const transport = new IframeChildTransport({
+  allowedOrigins: ['*']
 });
 ```
 
@@ -453,6 +691,14 @@ const transport = new TabClientTransport({
 
   <Accordion title="Can I use React/Vue inside the iframe?">
     Absolutely! The iframe is just HTML. Use any framework and register tools when your components mount.
+  </Accordion>
+
+  <Accordion title="Should I use Tab transports or Iframe transports?">
+    Use **Iframe transports** (`IframeParentTransport`/`IframeChildTransport`) when your iframe is on a different origin than the parent page. Use **Tab transports** when they're on the same origin. Iframe transports provide better cross-origin security and handle iframe loading timing automatically.
+  </Accordion>
+
+  <Accordion title="How do Iframe transports differ from Tab transports?">
+    Iframe transports are specifically designed for parent-child iframe communication with dedicated channels, ready handshake protocols, and explicit origin targeting. Tab transports work for same-context scenarios and support server discovery. Both use `postMessage` but with different messaging patterns.
   </Accordion>
 </AccordionGroup>
 

--- a/packages/transports.mdx
+++ b/packages/transports.mdx
@@ -27,6 +27,10 @@ npm install @mcp-b/transports @modelcontextprotocol/sdk
 
 Use `TabServerTransport` and `TabClientTransport` when your MCP server and client are running in the same browser tab. The transport uses `window.postMessage` for secure communication with origin validation.
 
+### Iframe Transports (Parent-Child Communication)
+
+Use `IframeParentTransport` and `IframeChildTransport` for cross-origin communication between a parent page and an iframe. These transports are specifically designed for iframe scenarios and support cross-origin messaging.
+
 ### Extension Transports (Cross-Context Communication)
 
 Use `ExtensionClientTransport` and `ExtensionServerTransport` for communication between browser extension components (sidebar, popup, background) and web pages with MCP servers.
@@ -112,6 +116,118 @@ await client.connect(transport);
 const result = await client.callTool({
   name: "createTodo",
   arguments: { todoText: "Buy groceries" },
+});
+```
+
+## Iframe Transport Examples
+
+### Server Setup (Inside Iframe)
+
+Create an MCP server inside an iframe that can be accessed by the parent page:
+
+```typescript
+import { IframeChildTransport } from "@mcp-b/transports";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { z } from "zod";
+
+// Create MCP server
+const server = new Server(
+  {
+    name: "IframeApp",
+    version: "1.0.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  }
+);
+
+// Register tools
+server.setRequestHandler('tools/list', async () => {
+  return {
+    tools: [
+      {
+        name: "getIframeData",
+        description: "Get data from the iframe application",
+        inputSchema: {
+          type: "object",
+          properties: {
+            key: { type: "string", description: "Data key to retrieve" }
+          },
+          required: ["key"]
+        }
+      }
+    ]
+  };
+});
+
+server.setRequestHandler('tools/call', async (request) => {
+  if (request.params.name === "getIframeData") {
+    const { key } = request.params.arguments;
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Retrieved: ${key}`,
+        },
+      ],
+    };
+  }
+  throw new Error(`Unknown tool: ${request.params.name}`);
+});
+
+// Connect to iframe transport
+const transport = new IframeChildTransport({
+  allowedOrigins: ["https://parent-app.com"], // Parent page origin
+  // or use ['*'] to allow any origin (less secure)
+});
+
+await server.connect(transport);
+```
+
+### Client Setup (Parent Page)
+
+Connect from the parent page to the iframe's MCP server:
+
+```typescript
+import { IframeParentTransport } from "@mcp-b/transports";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+// Get reference to iframe element
+const iframe = document.querySelector('iframe');
+
+// Wait for iframe to load
+iframe.addEventListener('load', async () => {
+  // Create transport targeting the iframe
+  const transport = new IframeParentTransport({
+    iframe: iframe,
+    targetOrigin: 'https://iframe-app.com', // Iframe page origin
+  });
+
+  // Create MCP client
+  const client = new Client(
+    {
+      name: "ParentPage",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {}
+    }
+  );
+
+  // Connect and use
+  await client.connect(transport);
+
+  // List available tools from iframe
+  const tools = await client.listTools();
+  console.log("Tools from iframe:", tools.tools);
+
+  // Call a tool from the iframe
+  const result = await client.callTool({
+    name: "getIframeData",
+    arguments: { key: "user-preferences" },
+  });
 });
 ```
 
@@ -269,10 +385,29 @@ const result = await client.callTool({
 |--------|------|----------|-------------|
 | `targetOrigin` | `string` | Yes | Origin of the target window |
 
+### IframeParentTransport Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `iframe` | `HTMLIFrameElement` | Yes | Reference to the iframe element |
+| `targetOrigin` | `string` | Yes | Expected origin of the iframe (for security) |
+| `channelId` | `string` | No | Channel identifier (default: 'mcp-iframe') |
+| `checkReadyRetryMs` | `number` | No | Retry interval for ready handshake in ms (default: 250) |
+
+### IframeChildTransport Options
+
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `allowedOrigins` | `string[]` | Yes | Whitelist of parent origins allowed to connect |
+| `channelId` | `string` | No | Channel identifier (default: 'mcp-iframe') |
+| `serverReadyRetryMs` | `number` | No | Retry interval for broadcasting ready signal in ms (default: 250) |
+
 ## Key Features
 
 - **Automatic Server Discovery**: Tab clients can discover available servers
-- **Cross-Origin Support**: Configure CORS for tab transports
+- **Cross-Origin Support**: Configure CORS for tab and iframe transports
+- **Parent-Child Communication**: Iframe transports enable secure cross-origin iframe communication
+- **Ready Handshake Protocol**: Iframe transports handle iframe loading timing issues automatically
 - **Cross-Extension Communication**: Extensions can expose APIs to other extensions
 - **Tool Namespacing**: Extension hub prefixes tools to avoid conflicts
 - **Connection Management**: Automatic cleanup when tabs close
@@ -281,12 +416,16 @@ const result = await client.callTool({
 
 ## Security Considerations
 
-- Tab transports respect origin restrictions
-- Extension transports use Chrome's secure message passing
-- External extension transports require `externally_connectable` manifest configuration
+- **Tab transports** respect origin restrictions
+- **Iframe transports** validate origins on both parent and child sides
+  - Always specify explicit `targetOrigin` (never use `'*'` in production)
+  - Configure `allowedOrigins` to whitelist only trusted parent domains
+  - Use `postMessage` API for secure cross-origin communication
+- **Extension transports** use Chrome's secure message passing
+- **External extension transports** require `externally_connectable` manifest configuration
 - Server extensions should validate incoming connections from other extensions
 - Configure `allowedOrigins` appropriately for your use case
-- Tools execute in their original context (web page or extension)
+- Tools execute in their original context (web page, iframe, or extension)
 
 ## Related Documentation
 


### PR DESCRIPTION
- Add IframeParentTransport and IframeChildTransport documentation to transports.mdx
- Include comprehensive examples for parent-child iframe communication
- Add configuration options tables for iframe transports
- Update security considerations for cross-origin iframe scenarios
- Add iframe transport examples to mcp-ui integration guide
- Include comparison guide for choosing between tab and iframe transports
- Add FAQs about iframe transport usage
- Update diagrams and security notes with iframe transport patterns

Related: WebMCP-org/npm-packages#6