### PR TITLE
Move live tool example to top level tab

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -71,8 +71,7 @@
             "pages": [
               "introduction",
               "quickstart",
-              "examples",
-              "live-tool-examples"
+              "examples"
             ]
           },
           {
@@ -221,6 +220,18 @@
             "group": "AI Indexing",
             "pages": [
               "llms-txt"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Live Tool Examples",
+        "icon": "wand-magic-sparkles",
+        "groups": [
+          {
+            "group": "Interactive Demos",
+            "pages": [
+              "live-tool-examples"
             ]
           }
         ]


### PR DESCRIPTION
- Removed live-tool-examples from Documentation > Getting Started group
- Created new "Live Tool Examples" tab with Interactive Demos group
- Maintains same icon (wand-magic-sparkles) for consistency