### PR TITLE
Check and Fix Dead Links

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -196,9 +196,9 @@ Open in Chrome with the MCP-B extension to test tools via the extension popup.
 
 <CardGroup>
   <Card
-    title="GitHub Discussions"
-    icon="comment"
-    href="https://github.com/WebMCP-org/WebMCP/discussions"
+    title="Discord Community"
+    icon="discord"
+    href="https://discord.gg/ZnHG4csJRB"
   >
     Get help from the community
   </Card>

--- a/extension/index.mdx
+++ b/extension/index.mdx
@@ -457,7 +457,7 @@ Userscripts can access and modify website content. Only install scripts from tru
   <Card
     title="GitHub Issues"
     icon="github"
-    href="https://github.com/WebMCP-org/WebMCP/issues"
+    href="https://github.com/WebMCP-org/npm-packages/issues"
   >
     Report bugs or request features
   </Card>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -46,7 +46,7 @@ These use cases are explicitly out of scope for WebMCP and should use other solu
 
 ### Key Terms
 
-For detailed terminology, see the [Glossary](/glossary). Key concepts:
+For detailed terminology, see the [Glossary](/concepts/glossary). Key concepts:
 
 - **WebMCP**: W3C Web Model Context API standard for exposing website tools to AI agents
 - **MCP-B**: Reference implementation that polyfills `navigator.modelContext` and bridges WebMCP with MCP

--- a/live-tool-examples.mdx
+++ b/live-tool-examples.mdx
@@ -19,7 +19,7 @@ This page demonstrates **live WebMCP tools** that register themselves with the b
 </Note>
 
 <CardGroup cols={3}>
-  <Card title="Build Your Own" icon="code" href="/guides/building-tools">
+  <Card title="Build Your Own" icon="code" href="/best-practices">
     Learn how to create custom tools
   </Card>
   <Card title="Tool Registration" icon="list-check" href="/concepts/tool-registration">

--- a/packages/extension-tools.mdx
+++ b/packages/extension-tools.mdx
@@ -441,7 +441,7 @@ const options: TabsApiToolsOptions = {
 **See also:**
 - [Advanced Patterns](/advanced) - Extension development patterns
 - [Troubleshooting](/troubleshooting) - Extension-specific issues
-- [Glossary](/glossary) - Extension terminology
+- [Glossary](/concepts/glossary) - Extension terminology
 
 ## External Resources
 

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -11,8 +11,8 @@ icon: 'wrench'
     If the initial clone fails, complete it manually:
 
     ```bash
-    git clone https://github.com/WebMCP-org/WebMCP.git
-    cd WebMCP
+    git clone https://github.com/WebMCP-org/npm-packages.git
+    cd npm-packages
     git pull origin main
     ```
   </Accordion>
@@ -340,19 +340,19 @@ If you're still experiencing issues:
 
 <Steps>
   <Step title="Check the documentation">
-    Review the [official docs](https://mcp-b.ai/docs) for updated information
+    Review the [official docs](https://docs.mcp-b.ai) for updated information
   </Step>
-  
+
   <Step title="Search existing issues">
-    Look for similar problems in [GitHub Issues](https://github.com/WebMCP-org/WebMCP/issues)
+    Look for similar problems in [GitHub Issues](https://github.com/WebMCP-org/npm-packages/issues)
   </Step>
-  
+
   <Step title="Join the community">
-    Ask questions in our [Discord server](https://discord.gg/your-discord)
+    Ask questions in our [Discord server](https://discord.gg/ZnHG4csJRB)
   </Step>
-  
+
   <Step title="Create an issue">
-    If it's a bug, [create a detailed issue](https://github.com/WebMCP-org/WebMCP/issues/new) with:
+    If it's a bug, [create a detailed issue](https://github.com/WebMCP-org/npm-packages/issues/new) with:
     - Steps to reproduce
     - Expected vs actual behavior
     - Browser and extension versions


### PR DESCRIPTION
- Replace non-existent WebMCP-org/WebMCP repository with npm-packages
- Update mcp-b.ai/docs to docs.mcp-b.ai
- Fix Discord invite link from placeholder to actual URL
- Correct /glossary internal links to /concepts/glossary
- Update /guides/building-tools to /best-practices

This fixes 9 broken links:
- 5 external GitHub links
- 1 external docs link
- 1 Discord link
- 2 internal glossary links
- 1 internal guide link