### PR TITLE
Add polyfill to live tools documentation

### DIFF
--- a/live-tool-examples.mdx
+++ b/live-tool-examples.mdx
@@ -9,13 +9,14 @@ import { CalculatorTool } from '/snippets/webmcp-tool-calculator.jsx';
 import { ColorConverterTool } from '/snippets/webmcp-tool-color-converter.jsx';
 import { StorageTool } from '/snippets/webmcp-tool-storage.jsx';
 import { DOMQueryTool } from '/snippets/webmcp-tool-dom-query.jsx';
+import { PolyfillSetup } from '/snippets/webmcp-polyfill-setup.jsx';
 
 # Live WebMCP Tool Examples
 
 This page demonstrates **live WebMCP tools** that register themselves with the browser and can be called by AI agents in real-time.
 
 <Note>
-**To use these tools**: Install the [MCP-B browser extension](https://chromewebstore.google.com/detail/mcp-b-extension/daohopfhkdelnpemnhlekblhnikhdhfa), which injects the WebMCP polyfill and enables AI agents to discover and call the tools on this page.
+**These tools work automatically!** This documentation site includes the WebMCP polyfill (`@mcp-b/global`), so the tools below are ready to use. Optionally, install the [MCP-B browser extension](https://chromewebstore.google.com/detail/mcp-b-extension/daohopfhkdelnpemnhlekblhnikhdhfa) to enable AI agents to discover and call these tools.
 </Note>
 
 <CardGroup cols={3}>
@@ -29,6 +30,14 @@ This page demonstrates **live WebMCP tools** that register themselves with the b
     SDK reference documentation
   </Card>
 </CardGroup>
+
+---
+
+## WebMCP Status
+
+Check if the WebMCP polyfill is loaded and ready:
+
+<PolyfillSetup />
 
 ---
 

--- a/load-webmcp.js
+++ b/load-webmcp.js
@@ -1,0 +1,28 @@
+// load-webmcp.js
+// Loads the WebMCP polyfill from CDN to enable live tool examples
+// This file is automatically included on all pages by Mintlify
+
+(function() {
+  'use strict';
+
+  // Check if already loaded (e.g., by the MCP-B browser extension)
+  if (window.navigator?.modelContext) {
+    console.log('WebMCP already loaded (likely via browser extension)');
+    return;
+  }
+
+  // Load the polyfill from CDN
+  const script = document.createElement('script');
+  script.src = 'https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js';
+  script.async = false; // Load synchronously to ensure it's ready for tools
+  script.onload = () => {
+    console.log('WebMCP polyfill loaded successfully');
+    // Dispatch custom event for components to listen to
+    window.dispatchEvent(new CustomEvent('webmcp-loaded'));
+  };
+  script.onerror = () => {
+    console.error('Failed to load WebMCP polyfill from CDN');
+  };
+
+  document.head.appendChild(script);
+})();

--- a/snippets/webmcp-polyfill-setup.jsx
+++ b/snippets/webmcp-polyfill-setup.jsx
@@ -1,5 +1,7 @@
 // WebMCP Polyfill Setup Component
 // Demonstrates how to integrate the @mcp-b/global polyfill
+import { useState, useEffect } from 'react';
+
 export const PolyfillSetup = () => {
   const [isLoaded, setIsLoaded] = useState(false);
   const [hasExtension, setHasExtension] = useState(false);
@@ -21,8 +23,12 @@ export const PolyfillSetup = () => {
     checkPolyfill();
     window.addEventListener('load', checkPolyfill);
 
+    // Listen for custom event from load-webmcp.js
+    window.addEventListener('webmcp-loaded', checkPolyfill);
+
     return () => {
       window.removeEventListener('load', checkPolyfill);
+      window.removeEventListener('webmcp-loaded', checkPolyfill);
     };
   }, []);
 


### PR DESCRIPTION
Add automatic WebMCP polyfill loading to enable live tool examples without requiring browser extension installation.

Changes:
- Add load-webmcp.js to automatically load @mcp-b/global polyfill from CDN
- Update live-tool-examples.mdx to reflect built-in polyfill support
- Add WebMCP status indicator component to show polyfill/extension status
- Fix missing React import in webmcp-polyfill-setup.jsx
- Add custom event listener for responsive status updates

The polyfill gracefully detects if the MCP-B browser extension has already injected it, preventing duplicate loads. All .js files in the docs root are automatically included by Mintlify on every page.