### PR TITLE
Fix live tools functionality issue

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7,6 +7,12 @@
     "light": "/logo/mcp-b-logo.png"
   },
   "favicon": "/favicon.ico",
+  "scripts": [
+    {
+      "src": "https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js",
+      "defer": true
+    }
+  ],
   "description": "WebMCP - W3C standard for making websites AI-accessible. Turn your JavaScript functions into tools that work with Claude, ChatGPT, and custom AI agents via navigator.modelContext.",
   "colors": {
     "primary": "#1F5EFF",


### PR DESCRIPTION
Add scripts configuration to docs.json to properly load the WebMCP polyfill from CDN. This ensures the navigator.modelContext API is available for live tool examples on the documentation site.

The scripts property loads @mcp-b/global polyfill with defer attribute, ensuring it loads after HTML parsing but before DOMContentLoaded.

This replaces the previous approach of using load-webmcp.js, which may not have been reliably loaded by Mintlify's auto-include mechanism.