### PR TITLE
Fix live tools bug on tab navigation

### DIFF
--- a/snippets/webmcp-tool-calculator.jsx
+++ b/snippets/webmcp-tool-calculator.jsx
@@ -12,7 +12,6 @@ export const CalculatorTool = () => {
     // Register the calculator tool with WebMCP
     const registerTool = async () => {
       if (typeof window === 'undefined' || !window.navigator?.modelContext) {
-        console.log('WebMCP not available');
         return;
       }
 
@@ -89,9 +88,14 @@ export const CalculatorTool = () => {
       }
     };
 
+    // Try to register immediately if polyfill is already loaded
     registerTool();
 
+    // Listen for polyfill load event
+    window.addEventListener('webmcp-loaded', registerTool);
+
     return () => {
+      window.removeEventListener('webmcp-loaded', registerTool);
       // Cleanup: unregister tool
       if (window.navigator?.modelContext?.unregisterTool) {
         window.navigator.modelContext.unregisterTool('calculator');

--- a/snippets/webmcp-tool-color-converter.jsx
+++ b/snippets/webmcp-tool-color-converter.jsx
@@ -143,9 +143,14 @@ export const ColorConverterTool = () => {
       }
     };
 
+    // Try to register immediately if polyfill is already loaded
     registerTool();
 
+    // Listen for polyfill load event
+    window.addEventListener('webmcp-loaded', registerTool);
+
     return () => {
+      window.removeEventListener('webmcp-loaded', registerTool);
       if (window.navigator?.modelContext?.unregisterTool) {
         window.navigator.modelContext.unregisterTool('color_converter');
       }

--- a/snippets/webmcp-tool-dom-query.jsx
+++ b/snippets/webmcp-tool-dom-query.jsx
@@ -129,9 +129,14 @@ export const DOMQueryTool = () => {
       }
     };
 
+    // Try to register immediately if polyfill is already loaded
     registerTool();
 
+    // Listen for polyfill load event
+    window.addEventListener('webmcp-loaded', registerTool);
+
     return () => {
+      window.removeEventListener('webmcp-loaded', registerTool);
       if (window.navigator?.modelContext?.unregisterTool) {
         window.navigator.modelContext.unregisterTool('dom_query');
       }

--- a/snippets/webmcp-tool-storage.jsx
+++ b/snippets/webmcp-tool-storage.jsx
@@ -241,9 +241,14 @@ export const StorageTool = () => {
       }
     };
 
+    // Try to register immediately if polyfill is already loaded
     registerTool();
 
+    // Listen for polyfill load event
+    window.addEventListener('webmcp-loaded', registerTool);
+
     return () => {
+      window.removeEventListener('webmcp-loaded', registerTool);
       if (window.navigator?.modelContext?.unregisterTool) {
         window.navigator.modelContext.unregisterTool('storage_set');
         window.navigator.modelContext.unregisterTool('storage_get');


### PR DESCRIPTION
Previously, tool registration failed on page refresh because React components mounted before the WebMCP polyfill finished loading. The tools would check once for window.navigator.modelContext, find it undefined, and return without registering.

Now all tool components listen for the 'webmcp-loaded' custom event that fires when the polyfill finishes loading, ensuring tools register correctly regardless of load timing.

Changes:
- Add webmcp-loaded event listener to all 4 tool components
- Keep immediate check for cases where polyfill is already loaded
- Properly clean up event listeners on component unmount

Fixes the issue where tools only appeared when navigating between tabs, but not when refreshing the page.