### PR TITLE
Add MCP integration documentation and links

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -219,12 +219,13 @@
         ]
       },
       {
-        "tab": "llms.txt",
-        "icon": "file-lines",
+        "tab": "For AI",
+        "icon": "robot",
         "groups": [
           {
-            "group": "AI Indexing",
+            "group": "AI Integration",
             "pages": [
+              "mcp-integration",
               "llms-txt"
             ]
           }

--- a/mcp-integration.mdx
+++ b/mcp-integration.mdx
@@ -5,38 +5,44 @@ sidebarTitle: 'MCP Integration'
 icon: 'plug'
 ---
 
-# WebMCP over Model Context Protocol (MCP)
+# WebMCP Documentation via MCP
 
-> Extend the capabilities of your AI agents with WebMCP's MCP Server
+> Connect your AI agent to WebMCP documentation for instant access to guides, examples, and API references
 
-Supercharge your AI agents with WebMCP documentation access via the Model Context Protocol (MCP) server.
+Give your AI assistant access to the complete WebMCP documentation through our Model Context Protocol (MCP) server. Your agent can explore the docs, find code examples, and help you implement WebMCP features.
 
 ## What is MCP?
 
 MCP is a protocol for integrating tools with AI agents. It greatly enhances the capabilities of your AI agents by providing them with real-time data and context.
 
-WebMCP offers a remote MCP server that you can connect to from most AI clients, giving your assistants instant access to WebMCP documentation, code examples, and best practices.
+The WebMCP documentation MCP server allows your AI assistant to explore and search this documentation site. When connected, your agent can help you by finding relevant guides, pulling up code examples, and answering questions about WebMCP implementation.
 
 ## How does it work?
 
-You need an MCP-capable agent environment to use WebMCP over MCP. Popular options include Claude Desktop, Claude Code, Cursor, Windsurf, and ChatGPT.
+You need an MCP-capable agent environment to connect to the WebMCP documentation server. Popular options include Claude Desktop, Claude Code, Cursor, Windsurf, and ChatGPT.
 
-Once connected, your AI assistant can search and reference WebMCP documentation to help you:
-- Implement WebMCP in your applications
+Once connected, your AI assistant can explore the documentation to help you:
+- Find relevant guides and tutorials
+- Locate specific code examples and patterns
+- Answer questions about WebMCP features and APIs
 - Troubleshoot integration issues
-- Find relevant code examples
-- Understand best practices and patterns
+- Understand best practices and implementation details
 
-## Connecting to WebMCP MCP
+## Connecting to the Documentation Server
 
-When you can specify an MCP URL, use `https://docs.mcp-b.ai/mcp`.
+The WebMCP documentation is available via MCP at `https://docs.mcp-b.ai/mcp`.
 
-If you have to specify a command, use:
+When your client supports direct URL configuration, use:
+```
+https://docs.mcp-b.ai/mcp
+```
+
+For command-based configuration, use:
 
 ```json
 {
   "mcpServers": {
-    "WebMCP": {
+    "WebMCP Docs": {
       "command": "npx",
       "args": ["mcp-remote", "https://docs.mcp-b.ai/mcp"]
     }
@@ -53,10 +59,10 @@ If you have to specify a command, use:
 Run the following command in your terminal:
 
 ```bash
-claude mcp add --transport http "WebMCP" "https://docs.mcp-b.ai/mcp"
+claude mcp add --transport http "WebMCP Docs" "https://docs.mcp-b.ai/mcp"
 ```
 
-Once added, Claude Code will have access to WebMCP documentation when you're working on projects.
+Once added, Claude Code can explore the WebMCP documentation to help you implement features, debug issues, and find code examples.
 
 <Info>
 See the [Claude Code documentation](./tools/claude-code) for more ways to optimize your WebMCP development workflow.
@@ -68,12 +74,12 @@ See the [Claude Code documentation](./tools/claude-code) for more ways to optimi
 
 1. Go to **Settings** → **Connectors**
 2. Click **Add custom connector**
-3. Name it "WebMCP"
+3. Name it "WebMCP Docs"
 4. Add `https://docs.mcp-b.ai/mcp` as the server URL
 5. Click **Save**
-6. Click **Connect** to enable the WebMCP documentation server
+6. Click **Connect** to connect to the documentation server
 
-Claude Desktop can now reference WebMCP documentation in your conversations.
+Claude Desktop can now explore and reference the WebMCP documentation in your conversations.
 
 </Accordion>
 
@@ -84,14 +90,14 @@ In `.cursor/mcp.json` in your project root, add:
 ```json
 {
   "mcpServers": {
-    "WebMCP": {
+    "WebMCP Docs": {
       "url": "https://docs.mcp-b.ai/mcp"
     }
   }
 }
 ```
 
-Restart Cursor for the changes to take effect.
+Restart Cursor to enable documentation access for your AI assistant.
 
 </Accordion>
 
@@ -102,7 +108,7 @@ In `mcp_config.json`, add:
 ```json
 {
   "mcpServers": {
-    "WebMCP": {
+    "WebMCP Docs": {
       "command": "npx",
       "args": ["mcp-remote", "https://docs.mcp-b.ai/mcp"]
     }
@@ -110,7 +116,7 @@ In `mcp_config.json`, add:
 }
 ```
 
-Restart Windsurf to connect to the WebMCP documentation server.
+Restart Windsurf to enable documentation access for your AI assistant.
 
 </Accordion>
 
@@ -119,12 +125,12 @@ Restart Windsurf to connect to the WebMCP documentation server.
 Add the following to your `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.webmcp]
+[mcp_servers.webmcp_docs]
 command = "npx"
 args = ["-y", "mcp-remote", "https://docs.mcp-b.ai/mcp"]
 ```
 
-Restart Codex for the changes to take effect.
+Restart Codex to enable documentation access for your AI assistant.
 
 </Accordion>
 
@@ -138,10 +144,10 @@ MCP is only available for paid users in beta on ChatGPT web, by enabling Develop
 2. Go to **Settings** → **Connectors**
 3. Click **Add MCP server**
 4. Add `https://docs.mcp-b.ai/mcp` as the server URL
-5. Name it "WebMCP"
+5. Name it "WebMCP Docs"
 6. Click **Save** and **Connect**
 
-ChatGPT can now access WebMCP documentation during conversations.
+ChatGPT can now explore the WebMCP documentation during conversations.
 
 </Accordion>
 
@@ -153,7 +159,7 @@ If you're using the Cline extension for VS Code:
 2. Navigate to Cline extension settings
 3. Find **MCP Servers** configuration
 4. Add a new server with:
-   - **Name**: WebMCP
+   - **Name**: WebMCP Docs
    - **URL**: `https://docs.mcp-b.ai/mcp`
 5. Save and restart VS Code
 
@@ -162,7 +168,7 @@ Alternatively, edit your Cline configuration file directly:
 ```json
 {
   "mcpServers": {
-    "WebMCP": {
+    "WebMCP Docs": {
       "url": "https://docs.mcp-b.ai/mcp"
     }
   }
@@ -173,9 +179,9 @@ Alternatively, edit your Cline configuration file directly:
 
 </AccordionGroup>
 
-## What you get with WebMCP MCP
+## What Your Agent Can Do
 
-Once connected, your AI assistant can:
+Once connected to the documentation server, your AI assistant can:
 
 <CardGroup cols={2}>
   <Card title="Search Documentation" icon="magnifying-glass">

--- a/mcp-integration.mdx
+++ b/mcp-integration.mdx
@@ -1,0 +1,261 @@
+---
+title: 'WebMCP over Model Context Protocol (MCP)'
+description: 'Connect AI assistants to WebMCP documentation through MCP - available for Claude Desktop, Claude Code, Cursor, VS Code, and more'
+sidebarTitle: 'MCP Integration'
+icon: 'plug'
+---
+
+# WebMCP over Model Context Protocol (MCP)
+
+> Extend the capabilities of your AI agents with WebMCP's MCP Server
+
+Supercharge your AI agents with WebMCP documentation access via the Model Context Protocol (MCP) server.
+
+## What is MCP?
+
+MCP is a protocol for integrating tools with AI agents. It greatly enhances the capabilities of your AI agents by providing them with real-time data and context.
+
+WebMCP offers a remote MCP server that you can connect to from most AI clients, giving your assistants instant access to WebMCP documentation, code examples, and best practices.
+
+## How does it work?
+
+You need an MCP-capable agent environment to use WebMCP over MCP. Popular options include Claude Desktop, Claude Code, Cursor, Windsurf, and ChatGPT.
+
+Once connected, your AI assistant can search and reference WebMCP documentation to help you:
+- Implement WebMCP in your applications
+- Troubleshoot integration issues
+- Find relevant code examples
+- Understand best practices and patterns
+
+## Connecting to WebMCP MCP
+
+When you can specify an MCP URL, use `https://docs.mcp-b.ai/mcp`.
+
+If you have to specify a command, use:
+
+```json
+{
+  "mcpServers": {
+    "WebMCP": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://docs.mcp-b.ai/mcp"]
+    }
+  }
+}
+```
+
+## Setup Instructions by Client
+
+<AccordionGroup>
+
+<Accordion title="Claude Code" icon="robot">
+
+Run the following command in your terminal:
+
+```bash
+claude mcp add --transport http "WebMCP" "https://docs.mcp-b.ai/mcp"
+```
+
+Once added, Claude Code will have access to WebMCP documentation when you're working on projects.
+
+<Info>
+See the [Claude Code documentation](./tools/claude-code) for more ways to optimize your WebMCP development workflow.
+</Info>
+
+</Accordion>
+
+<Accordion title="Claude Desktop" icon="desktop">
+
+1. Go to **Settings** → **Connectors**
+2. Click **Add custom connector**
+3. Name it "WebMCP"
+4. Add `https://docs.mcp-b.ai/mcp` as the server URL
+5. Click **Save**
+6. Click **Connect** to enable the WebMCP documentation server
+
+Claude Desktop can now reference WebMCP documentation in your conversations.
+
+</Accordion>
+
+<Accordion title="Cursor" icon="code">
+
+In `.cursor/mcp.json` in your project root, add:
+
+```json
+{
+  "mcpServers": {
+    "WebMCP": {
+      "url": "https://docs.mcp-b.ai/mcp"
+    }
+  }
+}
+```
+
+Restart Cursor for the changes to take effect.
+
+</Accordion>
+
+<Accordion title="Windsurf" icon="wind">
+
+In `mcp_config.json`, add:
+
+```json
+{
+  "mcpServers": {
+    "WebMCP": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://docs.mcp-b.ai/mcp"]
+    }
+  }
+}
+```
+
+Restart Windsurf to connect to the WebMCP documentation server.
+
+</Accordion>
+
+<Accordion title="Codex" icon="terminal">
+
+Add the following to your `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.webmcp]
+command = "npx"
+args = ["-y", "mcp-remote", "https://docs.mcp-b.ai/mcp"]
+```
+
+Restart Codex for the changes to take effect.
+
+</Accordion>
+
+<Accordion title="ChatGPT" icon="message">
+
+<Note>
+MCP is only available for paid users in beta on ChatGPT web, by enabling Developer Mode.
+</Note>
+
+1. Enable **Developer Mode** in ChatGPT settings
+2. Go to **Settings** → **Connectors**
+3. Click **Add MCP server**
+4. Add `https://docs.mcp-b.ai/mcp` as the server URL
+5. Name it "WebMCP"
+6. Click **Save** and **Connect**
+
+ChatGPT can now access WebMCP documentation during conversations.
+
+</Accordion>
+
+<Accordion title="VS Code (Cline Extension)" icon="code">
+
+If you're using the Cline extension for VS Code:
+
+1. Open VS Code settings
+2. Navigate to Cline extension settings
+3. Find **MCP Servers** configuration
+4. Add a new server with:
+   - **Name**: WebMCP
+   - **URL**: `https://docs.mcp-b.ai/mcp`
+5. Save and restart VS Code
+
+Alternatively, edit your Cline configuration file directly:
+
+```json
+{
+  "mcpServers": {
+    "WebMCP": {
+      "url": "https://docs.mcp-b.ai/mcp"
+    }
+  }
+}
+```
+
+</Accordion>
+
+</AccordionGroup>
+
+## What you get with WebMCP MCP
+
+Once connected, your AI assistant can:
+
+<CardGroup cols={2}>
+  <Card title="Search Documentation" icon="magnifying-glass">
+    Find relevant pages, code examples, and API references instantly
+  </Card>
+  <Card title="Get Code Examples" icon="code">
+    Access tested TypeScript and JavaScript examples for all WebMCP features
+  </Card>
+  <Card title="Understand Best Practices" icon="lightbulb">
+    Learn recommended patterns for tool registration, security, and performance
+  </Card>
+  <Card title="Troubleshoot Issues" icon="wrench">
+    Get help with common integration problems and debugging techniques
+  </Card>
+</CardGroup>
+
+## Example Usage
+
+After connecting the WebMCP MCP server, you can ask your AI assistant questions like:
+
+<AccordionGroup>
+  <Accordion title="Implementation Questions">
+    - "How do I register a tool with WebMCP in React?"
+    - "Show me how to set up the tab transport"
+    - "What's the best way to validate tool parameters?"
+  </Accordion>
+
+  <Accordion title="Debugging Help">
+    - "Why isn't my tool appearing in Claude Desktop?"
+    - "How do I handle errors in WebMCP tool handlers?"
+    - "What are common CORS issues with WebMCP?"
+  </Accordion>
+
+  <Accordion title="Architecture Questions">
+    - "How does WebMCP's architecture work?"
+    - "What's the difference between client and server transports?"
+    - "How do I secure my WebMCP implementation?"
+  </Accordion>
+</AccordionGroup>
+
+## Resources
+
+<CardGroup cols={2}>
+  <Card title="MCP Documentation" icon="book" href="https://modelcontextprotocol.io">
+    Learn more about the Model Context Protocol
+  </Card>
+  <Card title="WebMCP Quickstart" icon="rocket" href="./quickstart">
+    Get started with WebMCP in your application
+  </Card>
+  <Card title="GitHub Repository" icon="github" href="https://github.com/WebMCP-org">
+    View source code and contribute
+  </Card>
+  <Card title="Discord Community" icon="discord" href="https://discord.gg/ZnHG4csJRB">
+    Get help and share your projects
+  </Card>
+</CardGroup>
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Connection fails">
+    - Ensure you have an active internet connection
+    - Verify the URL is correct: `https://docs.mcp-b.ai/mcp`
+    - Try restarting your AI client application
+    - Check if your firewall or proxy is blocking the connection
+  </Accordion>
+
+  <Accordion title="Documentation not appearing">
+    - Confirm the MCP server is connected in your client settings
+    - Try disconnecting and reconnecting the server
+    - Restart your AI client application
+    - Check the client's MCP server logs for errors
+  </Accordion>
+
+  <Accordion title="Outdated information">
+    - The MCP server provides the latest published documentation
+    - If you notice discrepancies, please report them on our [GitHub issues](https://github.com/WebMCP-org/docs/issues)
+  </Accordion>
+</AccordionGroup>
+
+<Info>
+Have questions or issues? Join our [Discord community](https://discord.gg/ZnHG4csJRB) or [open an issue on GitHub](https://github.com/WebMCP-org/docs/issues).
+</Info>

--- a/mcp-integration.mdx
+++ b/mcp-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'WebMCP over Model Context Protocol (MCP)'
-description: 'Connect AI assistants to WebMCP documentation through MCP - available for Claude Desktop, Claude Code, Cursor, VS Code, and more'
+description: 'Connect AI assistants to WebMCP documentation through MCP for instant access to guides and examples'
 sidebarTitle: 'MCP Integration'
 icon: 'plug'
 ---


### PR DESCRIPTION
- Renamed 'llms.txt' tab to 'For AI' with robot icon
- Created comprehensive MCP integration documentation page
- Added setup instructions for Claude Code, Claude Desktop, Cursor, Windsurf, Codex, ChatGPT, and VS Code
- Included troubleshooting section and example usage
- Remote MCP server URL: https://docs.mcp-b.ai/mcp