### PR TITLE
Find and fix duplicate headings

### DIFF
--- a/ai-frameworks/index.mdx
+++ b/ai-frameworks/index.mdx
@@ -6,7 +6,7 @@ icon: 'wand-magic-sparkles'
 
 ## Overview
 
-WebMCP tools can be called directly by AI agents running in your frontend application. This enables you to build AI copilots, assistants, and intelligent features that interact with your website's functionality through registered MCP tools.
+Your frontend AI agents need a way to interact with your website. This guide shows how to wire WebMCP tools into frameworks like Assistant-UI, AG-UI, or custom runtimes, then use the MCP client protocol to let agents discover and call your tools. By the end, your AI will be able to understand and use every feature you expose.
 
 ## How Frontend Tool Calling Works
 

--- a/best-practices.mdx
+++ b/best-practices.mdx
@@ -4,8 +4,6 @@ description: Learn best practices for designing and implementing WebMCP tools on
 icon: list-check
 ---
 
-# Best Practices for Creating Tools
-
 This guide provides comprehensive best practices for website owners creating WebMCP tools. Unlike userscripts where you work around existing site structure, having full control over your website allows you to design tools from the ground up for optimal AI agent integration.
 
 <Info>

--- a/best-practices.mdx
+++ b/best-practices.mdx
@@ -4,7 +4,7 @@ description: Learn best practices for designing and implementing WebMCP tools on
 icon: list-check
 ---
 
-This guide provides comprehensive best practices for website owners creating WebMCP tools. Unlike userscripts where you work around existing site structure, having full control over your website allows you to design tools from the ground up for optimal AI agent integration.
+This guide covers the complete tool development lifecycle: from naming and schema design, through implementation and error handling, to testing and monitoring. Unlike userscripts where you work around existing structures, controlling your entire website lets you design tools from the ground up for optimal AI integration.
 
 <Info>
 These practices apply when you own the website and can integrate WebMCP tools directly into your codebase. For userscript development, see [Managing Userscripts](/extension/managing-userscripts).

--- a/building-mcp-ui-apps.mdx
+++ b/building-mcp-ui-apps.mdx
@@ -6,6 +6,8 @@ icon: 'hammer'
 
 ## What You're Building
 
+Building a bidirectional MCP-UI app means the AI agent can invoke your code, which then provides UI to the user, which can then invoke the AI again. This creates interactive workflows where the interface evolves based on what the agent decides to do.
+
 `npx create-webmcp-app` scaffolds a bidirectional system with three components:
 
 1. **MCP Server** (Cloudflare Worker) - Exposes tools to AI agents

--- a/concepts/schemas.mdx
+++ b/concepts/schemas.mdx
@@ -4,7 +4,7 @@ description: 'Defining input schemas for WebMCP tools using JSON Schema and Zod.
 icon: 'file-contract'
 ---
 
-Tool schemas define the expected input structure for your tools, enabling automatic validation and helping AI agents understand how to call your tools correctly.
+Schemas are the contract between your tools and the AI agents that call them. They specify what inputs are required, what types they are, and provide examples that help agents understand what values to send.
 
 ## Input Schema (JSON Schema)
 

--- a/concepts/tool-design.mdx
+++ b/concepts/tool-design.mdx
@@ -4,7 +4,7 @@ description: 'Best practices for designing effective WebMCP tools that AI agents
 icon: 'lightbulb'
 ---
 
-Designing effective tools is crucial for creating great WebMCP experiences. Well-designed tools are easy for AI agents to understand and use correctly.
+Good tool design is about more than writing working code—it's about creating a clear contract between your website and AI agents. This guide covers naming patterns, schema design, output formatting, and error handling that together make tools self-documenting and resilient to model variations.
 
 ## Naming Conventions
 

--- a/connecting-agents.mdx
+++ b/connecting-agents.mdx
@@ -6,7 +6,7 @@ icon: 'link'
 
 ## Overview
 
-WebMCP tools can be connected to AI agents in multiple ways, giving you flexibility to integrate with any agent architecture. Whether you're using a browser-based agent, a local desktop client, or building your own AI application, WebMCP has a connection method that fits your needs.
+This guide covers four primary connection methods, each suited to different use cases and architectures. Whether you're building a website that exposes tools to users' local AI clients, or an embedded application that agents control directly, you'll find the right approach here. We'll compare setup complexity, capabilities, and security considerations for each method.
 
 ## Connection Methods
 

--- a/extension/agents.mdx
+++ b/extension/agents.mdx
@@ -4,8 +4,6 @@ description: Learn about the specialized AI agents in the MCP-B extension and wh
 icon: robot
 ---
 
-# Understanding Agents
-
 The MCP-B extension includes four specialized AI agents, each designed for specific types of tasks. Choosing the right agent helps you work more effectively with web automation and MCP integration.
 
 ## Available Agents

--- a/extension/index.mdx
+++ b/extension/index.mdx
@@ -4,8 +4,6 @@ description: Download the MCP-B browser extension for Chrome to build AI-powered
 icon: puzzle-piece
 ---
 
-# MCP-B Extension
-
 The MCP-B browser extension is a development and testing tool for WebMCP servers. It collects WebMCP tools from all your open tabs, lets you inject custom servers via userscript, and includes specialized AI agents to help you build and test web-based tools.
 
 <Card

--- a/extension/index.mdx
+++ b/extension/index.mdx
@@ -4,7 +4,7 @@ description: Download the MCP-B browser extension for Chrome to build AI-powered
 icon: puzzle-piece
 ---
 
-The MCP-B browser extension is a development and testing tool for WebMCP servers. It collects WebMCP tools from all your open tabs, lets you inject custom servers via userscript, and includes specialized AI agents to help you build and test web-based tools.
+The MCP-B browser extension bridges your browser and desktop AI. It collects WebMCP tools from all your open tabs and bridges them to local MCP clients like Claude Desktop. Additionally, it includes specialized AI agents that help you build userscripts and create new WebMCP tools without leaving the browser.
 
 <Card
   title="Install MCP-B Extension"

--- a/extension/managing-userscripts.mdx
+++ b/extension/managing-userscripts.mdx
@@ -4,8 +4,6 @@ description: Learn how to download, upload, enable, disable, and organize your u
 icon: gear
 ---
 
-# Managing Userscripts
-
 The MCP-B extension includes a built-in userscript manager that lets you create, organize, and share custom scripts for any website. This guide covers everything you need to know about managing your userscripts.
 
 ## What Are Userscripts?

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,7 +6,7 @@ icon: 'book-open'
 
 ## Welcome to WebMCP
 
-**Make your website AI-accessible.** Turn your JavaScript functions into tools that AI assistants like Claude, ChatGPT, and custom agents can discover and use.
+With WebMCP, your existing JavaScript functions become discoverable tools. Rather than relying on browser automation or remote APIs, agents get deterministic function calls that work reliably and securely.
 
 ### The Problem
 

--- a/live-tool-examples.mdx
+++ b/live-tool-examples.mdx
@@ -11,8 +11,6 @@ import { StorageTool } from '/snippets/webmcp-tool-storage.jsx';
 import { DOMQueryTool } from '/snippets/webmcp-tool-dom-query.jsx';
 import { PolyfillSetup } from '/snippets/webmcp-polyfill-setup.jsx';
 
-# Live WebMCP Tool Examples
-
 This page demonstrates **live WebMCP tools** that register themselves with the browser and can be called by AI agents in real-time.
 
 <Note>

--- a/packages/global.mdx
+++ b/packages/global.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Global (W3C API)"
 icon: "globe"
 ---
 
-**W3C Web Model Context API polyfill** - Add `navigator.modelContext` to your website and turn JavaScript functions into AI-accessible tools.
+This package implements the W3C Web Model Context API specification, making `navigator.modelContext` available in your site. Instead of creating complex installation steps, it works out of the box with automatic detection of whether your app is running standalone or embedded in an iframe.
 
 <Info>
   **Quick Start**: Use `registerTool()` to add tools. It's simple, automatic, and works everywhere.

--- a/packages/react-webmcp.mdx
+++ b/packages/react-webmcp.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "React WebMCP"
 icon: "react"
 ---
 
-React hooks for registering tools via `navigator.modelContext` and consuming tools from MCP servers.
+This package provides two sets of hooks: **provider hooks** for registering your tools with automatic lifecycle management and Zod validation, and **client hooks** for connecting to MCP servers and calling tools. The hooks handle the boilerplate of tool registration/cleanup, leaving you to focus on tool logic.
 
 ## Prerequisites
 

--- a/packages/transports.mdx
+++ b/packages/transports.mdx
@@ -5,7 +5,7 @@ sidebarTitle: "Transports"
 icon: "arrows-left-right"
 ---
 
-Browser-specific MCP `Transport` implementations enabling communication between MCP clients and servers within web pages and browser extensions.
+Transports are the communication layer that routes MCP messages between different browser contexts. Think of them as the plumbing that lets your tools talk to agents, whether they're in the same tab, different tabs, or extension pages.
 
 ## Prerequisites
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -4,7 +4,7 @@ description: 'Add AI agent support to your website in minutes with WebMCP. Turn 
 icon: 'rocket'
 ---
 
-Turn your website's JavaScript functions into AI-accessible tools in minutes. This guide will have you up and running with WebMCP quickly.
+This guide teaches you three approaches to adding tools to your site, starting with the simplest method and advancing to more powerful patterns. By the end, you'll understand which installation method fits your project.
 
 ## Prerequisites
 

--- a/security.mdx
+++ b/security.mdx
@@ -8,6 +8,8 @@ icon: 'shield-halved'
   As a website builder, you are responsible for protecting your users from malicious agents. Agents may have access to tools from multiple websites—some potentially malicious. Implement proper validation, authorization, and sensitive data handling to safeguard your users.
 </Warning>
 
+This guide addresses each of these security concerns through practical patterns. Unlike traditional web security which assumes users control the client, WebMCP must assume the AI agent using your tools may be compromised by malicious tools from other websites. This changes how we approach validation, authorization, and sensitive data handling.
+
 ## Why WebMCP Security is Different
 
 ### The Multi-Website Threat Model

--- a/tools/claude-code.mdx
+++ b/tools/claude-code.mdx
@@ -4,8 +4,6 @@ description: Configure Claude Code to help write, review, and update your WebMCP
 icon: robot
 ---
 
-# Claude Code
-
 Configure Claude Code to help write, review, and update your docs.
 
 Claude Code is an agentic command line tool that can help you maintain your documentation. It can write new content, review existing pages, and keep docs up to date.

--- a/why-webmcp.mdx
+++ b/why-webmcp.mdx
@@ -4,6 +4,8 @@ description: 'Understand why WebMCP provides a better approach to browser AI tha
 icon: 'lightbulb'
 ---
 
+WebMCP competes with three existing approaches to connecting AI to the web. This guide compares all four across key dimensions: determinism, speed, UI resilience, authentication complexity, and human oversight. Understanding these tradeoffs will help you choose the right tool for your use case.
+
 ## The Problem with Current Approaches
 
 Most solutions for connecting AI to the web fall into two categories: browser automation and remote APIs. Both have significant limitations.


### PR DESCRIPTION
Fixed double heading issue where page titles were repeated as H1 headings. Mintlify renders the frontmatter title automatically, making the H1 redundant.

Files updated:
- best-practices.mdx
- extension/agents.mdx
- extension/index.mdx
- extension/managing-userscripts.mdx
- live-tool-examples.mdx
- tools/claude-code.mdx