### PR TITLE
Fix parsing error in performance documentation

### DIFF
--- a/concepts/performance.mdx
+++ b/concepts/performance.mdx
@@ -415,10 +415,10 @@ Track how long tools take to execute:
 
 Set performance targets for your tools:
 
-- ⚡ **Instant**: <100ms - Data reads, simple computations
+- ⚡ **Instant**: \<100ms - Data reads, simple computations
 - ✅ **Fast**: 100-500ms - API calls, database queries
 - ⚠️ **Acceptable**: 500ms-2s - Complex operations, file processing
-- ❌ **Too slow**: >2s - Consider breaking into smaller steps or showing progress
+- ❌ **Too slow**: \>2s - Consider breaking into smaller steps or showing progress
 
 ## Caching
 

--- a/snippets/interactive-quickstart.jsx
+++ b/snippets/interactive-quickstart.jsx
@@ -1,8 +1,8 @@
 // Interactive Quickstart Component
 // A tool builder that shows code being generated in real-time with syntax highlighting
-import { useState, useEffect, useRef, useMemo } from 'react';
 
 export const InteractiveQuickstart = () => {
+  const { useState, useEffect, useRef, useMemo } = React;
   // Simple syntax highlighter for JavaScript/TypeScript - defined inside component for Mintlify compatibility
   const highlightCode = (code) => {
     const patterns = [

--- a/snippets/webmcp-polyfill-setup.jsx
+++ b/snippets/webmcp-polyfill-setup.jsx
@@ -1,8 +1,8 @@
 // WebMCP Polyfill Setup Component
 // Demonstrates how to integrate the @mcp-b/global polyfill
-import { useState, useEffect } from 'react';
 
 export const PolyfillSetup = () => {
+  const { useState, useEffect } = React;
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
- Escape < and > in performance.mdx to prevent JSX parsing errors
- Remove React imports from snippets, use global React object instead (Mintlify requires import paths to start with /snippets/)