### PR TITLE
docs: add framework gotchas guide for RSC and modern React frameworks

### DIFF
--- a/ai-frameworks/framework-gotchas.mdx
+++ b/ai-frameworks/framework-gotchas.mdx
@@ -1,0 +1,459 @@
+---
+title: 'Framework Gotchas'
+description: 'Common issues when using WebMCP with React Server Components, Next.js App Router, and other modern frameworks. Solutions for tool registration failures and rendering boundaries.'
+icon: 'triangle-exclamation'
+---
+
+When integrating WebMCP with modern React frameworks, you may encounter issues related to server/client rendering boundaries. This guide covers the most common gotchas and their solutions.
+
+## React Server Components
+
+<AccordionGroup>
+  <Accordion title="Tools must be registered in client components">
+    **Symptom:** Your tools don't appear in the extension, and you see logs like:
+
+    ```
+    [MCP Bridge] Handling list_tools request
+    [MCP Proxy] Sending 0 tools with type: register-tools
+    ```
+
+    **Cause:** React Server Components (RSC) run on the server and strip away event listeners, handlers, and browser APIs. The `useWebMCP` hook requires client-side React features to function.
+
+    **Solution:** Add the `"use client"` directive at the top of any component that registers tools:
+
+    ```tsx "ProductTools.tsx" {1}
+    "use client";
+
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+    import { z } from 'zod';
+
+    export function ProductTools() {
+      useWebMCP({
+        name: 'add_to_cart',
+        description: 'Add a product to the shopping cart',
+        inputSchema: {
+          productId: z.string(),
+          quantity: z.number().min(1)
+        },
+        handler: async (input) => {
+          await addToCart(input.productId, input.quantity);
+          return { success: true };
+        }
+      });
+
+      return null; // Or your UI
+    }
+    ```
+
+    <Warning>
+      Without `"use client"`, your component renders on the server where `navigator.modelContext` doesn't exist, causing silent failures.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="The useWebMCP hook doesn't work in RSC">
+    React hooks cannot run in Server Components. If you try to use `useWebMCP` in a Server Component, you'll get an error like:
+
+    ```
+    Error: useState only works in Client Components. Add the "use client" directive at the top of the file.
+    ```
+
+    **Solution:** Extract tool registration into a dedicated client component:
+
+    ```tsx "page.tsx (Server Component)"
+    // This is a Server Component - no "use client" directive
+    import { ProductTools } from './ProductTools';
+    import { fetchProducts } from './data';
+
+    export default async function ProductPage() {
+      const products = await fetchProducts(); // Server-side data fetching
+
+      return (
+        <div>
+          <ProductTools /> {/* Client component handles tool registration */}
+          <ProductList products={products} />
+        </div>
+      );
+    }
+    ```
+
+    ```tsx "ProductTools.tsx (Client Component)"
+    "use client";
+
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+
+    export function ProductTools() {
+      useWebMCP({
+        name: 'search_products',
+        description: 'Search for products by name',
+        inputSchema: { query: z.string() },
+        handler: async ({ query }) => {
+          // Client-side search logic
+          return { results: [] };
+        }
+      });
+
+      return null;
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Passing server data to client tool handlers">
+    You may need to use server-fetched data in your tool handlers. Pass data as props to your client component:
+
+    ```tsx "page.tsx"
+    import { ProductTools } from './ProductTools';
+    import { getProducts, getCategories } from './data';
+
+    export default async function Page() {
+      const [products, categories] = await Promise.all([
+        getProducts(),
+        getCategories()
+      ]);
+
+      return (
+        <ProductTools
+          initialProducts={products}
+          categories={categories}
+        />
+      );
+    }
+    ```
+
+    ```tsx "ProductTools.tsx"
+    "use client";
+
+    import { useState } from 'react';
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+    import { z } from 'zod';
+
+    interface Props {
+      initialProducts: Product[];
+      categories: Category[];
+    }
+
+    export function ProductTools({ initialProducts, categories }: Props) {
+      const [products, setProducts] = useState(initialProducts);
+
+      useWebMCP({
+        name: 'filter_by_category',
+        description: 'Filter products by category',
+        inputSchema: {
+          categoryId: z.enum(categories.map(c => c.id) as [string, ...string[]])
+        },
+        handler: async ({ categoryId }) => {
+          const filtered = products.filter(p => p.categoryId === categoryId);
+          return {
+            count: filtered.length,
+            products: filtered.map(p => p.name)
+          };
+        }
+      });
+
+      return null;
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Next.js App Router
+
+<AccordionGroup>
+  <Accordion title="Tools in layout.tsx don't register">
+    If you place tool registration in `layout.tsx` without the client directive, tools won't register because layouts are Server Components by default.
+
+    **Solution:** Create a separate client component for tools:
+
+    ```tsx "app/layout.tsx"
+    import { GlobalTools } from '@/components/GlobalTools';
+
+    export default function RootLayout({ children }) {
+      return (
+        <html>
+          <body>
+            <GlobalTools />
+            {children}
+          </body>
+        </html>
+      );
+    }
+    ```
+
+    ```tsx "components/GlobalTools.tsx"
+    "use client";
+
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+
+    export function GlobalTools() {
+      useWebMCP({
+        name: 'get_current_route',
+        description: 'Get the current page route',
+        handler: async () => {
+          return { route: window.location.pathname };
+        }
+      });
+
+      return null;
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="McpClientProvider placement with App Router">
+    The `McpClientProvider` must be in a client component. Create a providers wrapper:
+
+    ```tsx "app/providers.tsx"
+    "use client";
+
+    import { McpClientProvider } from '@mcp-b/react-webmcp';
+    import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+    import { TabClientTransport } from '@mcp-b/transports';
+
+    const client = new Client({ name: 'MyApp', version: '1.0.0' });
+    const transport = new TabClientTransport('mcp');
+
+    export function Providers({ children }: { children: React.ReactNode }) {
+      return (
+        <McpClientProvider client={client} transport={transport}>
+          {children}
+        </McpClientProvider>
+      );
+    }
+    ```
+
+    ```tsx "app/layout.tsx"
+    import { Providers } from './providers';
+
+    export default function RootLayout({ children }) {
+      return (
+        <html>
+          <body>
+            <Providers>{children}</Providers>
+          </body>
+        </html>
+      );
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Dynamic routes and tool registration">
+    When registering tools in dynamic route pages, ensure the component re-registers when route params change:
+
+    ```tsx "app/posts/[id]/PostTools.tsx"
+    "use client";
+
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+    import { z } from 'zod';
+
+    export function PostTools({ postId }: { postId: string }) {
+      // Tool name includes postId to make it unique per page
+      useWebMCP({
+        name: `post_${postId}_like`,
+        description: `Like post ${postId}`,
+        handler: async () => {
+          await likePost(postId);
+          return { success: true };
+        }
+      });
+
+      // Or use a generic tool that reads current context
+      useWebMCP({
+        name: 'like_current_post',
+        description: 'Like the currently viewed post',
+        handler: async () => {
+          await likePost(postId); // Captures current postId
+          return { success: true, postId };
+        }
+      });
+
+      return null;
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Other Frameworks
+
+<AccordionGroup>
+  <Accordion title="Remix: Loader data in tool handlers">
+    In Remix, use client components for tool registration and access loader data via hooks:
+
+    ```tsx "app/routes/products.tsx"
+    import { json } from '@remix-run/node';
+    import { useLoaderData } from '@remix-run/react';
+    import { ProductTools } from '~/components/ProductTools';
+
+    export async function loader() {
+      const products = await getProducts();
+      return json({ products });
+    }
+
+    export default function Products() {
+      const { products } = useLoaderData<typeof loader>();
+
+      return (
+        <div>
+          <ProductTools products={products} />
+          {/* ... */}
+        </div>
+      );
+    }
+    ```
+
+    ```tsx "app/components/ProductTools.tsx"
+    "use client"; // Works in Remix with React 18+
+
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+
+    export function ProductTools({ products }) {
+      useWebMCP({
+        name: 'search_products',
+        description: 'Search loaded products',
+        inputSchema: { query: z.string() },
+        handler: async ({ query }) => {
+          const results = products.filter(p =>
+            p.name.toLowerCase().includes(query.toLowerCase())
+          );
+          return { results };
+        }
+      });
+
+      return null;
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Astro: Island architecture">
+    In Astro, use React islands with the `client:load` directive:
+
+    ```astro "src/pages/index.astro"
+    ---
+    import { ProductTools } from '../components/ProductTools';
+    ---
+
+    <html>
+      <body>
+        <!-- This React component hydrates on the client -->
+        <ProductTools client:load />
+      </body>
+    </html>
+    ```
+
+    ```tsx "src/components/ProductTools.tsx"
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+
+    export function ProductTools() {
+      useWebMCP({
+        name: 'my_tool',
+        description: 'A tool that works in Astro',
+        handler: async () => ({ success: true })
+      });
+
+      return null;
+    }
+    ```
+
+    <Note>
+      Use `client:load` for tools that should be available immediately. `client:idle` or `client:visible` may delay tool registration.
+    </Note>
+  </Accordion>
+
+  <Accordion title="Vite/Create React App: No special handling needed">
+    Traditional SPAs built with Vite or Create React App don't have server components, so tools work everywhere:
+
+    ```tsx "src/App.tsx"
+    import { useWebMCP } from '@mcp-b/react-webmcp';
+
+    function App() {
+      // Works anywhere in a standard SPA
+      useWebMCP({
+        name: 'my_tool',
+        description: 'Works without any special handling',
+        handler: async () => ({ success: true })
+      });
+
+      return <div>My App</div>;
+    }
+    ```
+
+    If you're migrating to Next.js App Router or another RSC-enabled framework, you'll need to add `"use client"` directives to components that use hooks.
+  </Accordion>
+</AccordionGroup>
+
+## Debugging Tips
+
+<AccordionGroup>
+  <Accordion title="Check if your component is a client component">
+    Add a simple check to verify your component runs on the client:
+
+    ```tsx
+    "use client";
+
+    import { useEffect } from 'react';
+
+    export function MyTools() {
+      useEffect(() => {
+        console.log('Client component mounted');
+        console.log('navigator.modelContext:', 'modelContext' in navigator);
+      }, []);
+
+      // ... tool registration
+    }
+    ```
+
+    If you don't see the console log, your component isn't hydrating on the client.
+  </Accordion>
+
+  <Accordion title="Verify tool registration in browser console">
+    Check if tools are being registered:
+
+    ```javascript
+    // In browser DevTools console
+    if ('modelContext' in navigator) {
+      console.log('WebMCP is available');
+    }
+
+    // If using @mcp-b/global, check the bridge
+    if (window.__mcpBridge) {
+      console.log('Registered tools:', window.__mcpBridge.tools);
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Common error messages">
+    | Error | Cause | Solution |
+    |-------|-------|----------|
+    | `useState only works in Client Components` | Using hooks in Server Component | Add `"use client"` directive |
+    | `navigator is not defined` | Code running on server | Move to client component |
+    | `0 tools` in extension | Tools in Server Component | Add `"use client"` to tool component |
+    | `modelContext is not defined` | `@mcp-b/global` not imported | Import `@mcp-b/global` in client entry |
+  </Accordion>
+</AccordionGroup>
+
+## Quick Reference
+
+| Framework | Default Component Type | Tool Registration Location |
+|-----------|----------------------|---------------------------|
+| Next.js App Router | Server | Client components with `"use client"` |
+| Next.js Pages Router | Client | Any component |
+| Remix | Server (v2+) | Client components |
+| Astro | Static | React islands with `client:load` |
+| Vite/CRA | Client | Any component |
+
+## Related Resources
+
+<CardGroup cols={2}>
+  <Card title="Setup Guide" icon="gear" href="/ai-frameworks/setup">
+    Installation and configuration
+  </Card>
+
+  <Card title="React WebMCP" icon="react" href="/packages/react-webmcp">
+    Complete React hooks reference
+  </Card>
+
+  <Card title="Troubleshooting" icon="wrench" href="/troubleshooting">
+    General troubleshooting guide
+  </Card>
+
+  <Card title="Best Practices" icon="stars" href="/ai-frameworks/best-practices">
+    Optimization patterns
+  </Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -213,7 +213,8 @@
             "group": "Integration Guides",
             "pages": [
               "ai-frameworks/setup",
-              "ai-frameworks/best-practices"
+              "ai-frameworks/best-practices",
+              "ai-frameworks/framework-gotchas"
             ]
           }
         ]


### PR DESCRIPTION
Add documentation explaining common issues when using WebMCP with:
- React Server Components (tools must use "use client" directive)
- Next.js App Router (provider placement, dynamic routes)
- Other frameworks (Remix, Astro, Vite/CRA)

Includes debugging tips and quick reference table for default
component types across frameworks.