### PR TITLE
docs: simplify intro docs for clarity and reduce redundancy

### DIFF
--- a/concepts/overview.mdx
+++ b/concepts/overview.mdx
@@ -1,58 +1,47 @@
 ---
-title: 'What is WebMCP?'
-description: 'Understanding the WebMCP standard, its design philosophy, and relationship to the Model Context Protocol'
+title: 'Core Concepts'
+description: 'Key concepts and terminology for understanding WebMCP architecture'
 icon: 'circle-info'
 ---
 
-<Note>
-  **TL;DR:** WebMCP lets you turn JavaScript functions into AI-accessible tools using `navigator.modelContext.registerTool()`. AI agents can then discover and call these tools to help users interact with your website.
-</Note>
+This page explains the core concepts you'll encounter when working with WebMCP. For a high-level introduction, see the [Introduction](/introduction).
 
-## What is WebMCP?
+## The Core API
 
-**WebMCP** (Web Model Context Protocol) is a **W3C web standard** currently being incubated by the [Web Machine Learning Community Group](https://www.w3.org/community/webmachinelearning/) that defines how websites expose structured tools to AI agents through the browser's `navigator.modelContext` API.
+WebMCP centers around one key method: `navigator.modelContext.registerTool()`. This browser API lets you expose JavaScript functions as structured tools that AI agents can discover and call.
 
-- **W3C Specification**: [github.com/webmachinelearning/webmcp](https://github.com/webmachinelearning/webmcp)
-- **Technical Proposal**: [WebMCP API Proposal](https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md)
+```javascript
+navigator.modelContext.registerTool({
+  name: 'add_to_cart',
+  description: 'Add a product to the shopping cart',
+  inputSchema: { /* ... */ },
+  async execute({ productId, quantity }) {
+    // Your existing logic
+  }
+});
+```
 
-### Design Philosophy
+## WebMCP vs MCP
 
-WebMCP is built on a **human-in-the-loop** philosophy where the human web interface remains primary and AI agents augment (rather than replace) user interaction. This means:
+WebMCP is inspired by Anthropic's [Model Context Protocol (MCP)](https://modelcontextprotocol.io) but adapted for web browsers:
 
-- Users maintain visibility and control over all agent actions
-- Tools enable collaborative workflows between humans and AI
-- The web page UI remains the primary interaction method
+| Aspect | MCP | WebMCP |
+|--------|-----|--------|
+| **Environment** | Backend servers | Browser |
+| **Use case** | Server-to-agent | Human-in-the-loop |
+| **Authentication** | OAuth 2.1 | Inherits user session |
+| **API** | MCP SDK | `navigator.modelContext` |
 
-## Relationship to MCP
+Both protocols are complementary:
+- **Use MCP** for backend services and server-to-agent communication
+- **Use WebMCP** for browser-based tools where users are present
 
-WebMCP is inspired by Anthropic's [Model Context Protocol (MCP)](https://modelcontextprotocol.io) but adapted specifically for web browsers. While WebMCP shares similar concepts with MCP (tools, resources, structured communication), it is evolving as an independent web standard with its own specification path.
+## MCP-B: The Reference Implementation
 
-### Key Architectural Decision: SDK vs Transport
+Since browsers don't yet natively support `navigator.modelContext`, **MCP-B** provides a polyfill that:
 
-The W3C community decided to implement WebMCP as an **SDK/abstraction layer** rather than a pure transport. This architectural choice provides important benefits:
-
-1. **Browser implements WebMCP primitives** - `navigator.modelContext` is a web-native API, not just a message pipe
-2. **Protocol independence** - Browsers can maintain backwards compatibility as MCP evolves without breaking existing implementations
-3. **Platform-specific security** - Web security models (same-origin policy, CSP) are natively enforced at the browser level
-4. **Declarative future** - Enables future declarative APIs (e.g., manifest-based tool registration)
-
-**MCP-B's Role**: The MCP-B packages provide:
-1. **W3C API polyfill** - Implements `navigator.modelContext` for browsers that don't yet support it natively
-2. **Translation layer** - Bridges between WebMCP's web-native API and the MCP protocol
-
-This dual role allows:
-- Tools declared in WebMCP format to work with MCP clients
-- Tools declared in MCP format to work with WebMCP browsers
-- Version independence as both standards evolve
-- Web-specific security features (same-origin policy, CSP)
-
-### Complementary, Not Competing
-
-Both protocols serve different purposes and can work together:
-
-- **Use MCP** for backend services, server-to-agent communication, headless integrations
-- **Use WebMCP** for browser-based tools, user-present workflows, client-side interactions
-- Both protocols can coexist in the same application
+1. **Implements the W3C API** - Adds `navigator.modelContext` to any browser
+2. **Bridges to MCP** - Translates WebMCP tools to MCP format for compatibility with existing AI frameworks
 
 ## Next Steps
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -14,9 +14,7 @@ AI assistants are great at conversation, but they can't reliably interact with y
 
 ### The Solution
 
-**WebMCP** is a W3C web standard (currently being incubated by the [Web Machine Learning Community Group](https://www.w3.org/community/webmachinelearning/)) that lets websites expose structured tools to AI agents through the `navigator.modelContext` API.
-
-With WebMCP, your existing JavaScript functions become discoverable tools. AI assistants can then help users by directly calling your website's functionality - all while respecting authentication and permissions.
+**WebMCP** is a W3C web standard (currently being incubated by the [Web Machine Learning Community Group](https://www.w3.org/community/webmachinelearning/)) that lets websites expose structured tools to AI agents through the `navigator.modelContext` API. AI assistants can then help users by directly calling your website's functionality - all while respecting authentication and permissions.
 
 ### Design Philosophy
 
@@ -131,178 +129,49 @@ For detailed terminology, see the [Glossary](/concepts/glossary). Key concepts:
   **Want to understand the architecture first?** Check out [Core Concepts](/concepts/overview) for diagrams and detailed explanations of how everything works together.
 </Info>
 
-## Community
-
-<CardGroup cols={3}>
-  <Card
-    title="Discord"
-    icon="discord"
-    href="https://discord.gg/ZnHG4csJRB"
-  >
-    Join our community for support and discussions
-  </Card>
-  <Card
-    title="NPM"
-    icon="npm"
-    href="https://www.npmjs.com/package/@mcp-b/transports"
-  >
-    Install our packages from NPM
-  </Card>
-  <Card
-    title="License"
-    icon="scale-balanced"
-    href="https://github.com/WebMCP-org/npm-packages/blob/main/LICENSE"
-  >
-    MIT License
-  </Card>
-</CardGroup>
-
-## Quick Example
-
-Get started in under 2 minutes:
-
-<Tabs>
-  <Tab title="React">
-    Use the `useWebMCP` hook for automatic tool registration:
-
-    ```tsx
-    import '@mcp-b/global';
-    import { useWebMCP } from '@mcp-b/react-webmcp';
-    import { z } from 'zod';
-
-    function ProductPage({ productId }) {
-      useWebMCP({
-        name: 'add_to_cart',
-        description: 'Add this product to shopping cart',
-        inputSchema: {
-          quantity: z.number().min(1).default(1)
-        },
-        handler: async ({ quantity }) => {
-          await addToCart(productId, quantity);
-          return { success: true, quantity };
-        }
-      });
-
-      return <div>Product Details</div>;
-    }
-    ```
-  </Tab>
-
-  <Tab title="Vanilla JS">
-    Use `registerTool()` to register tools:
-
-    ```javascript
-    import '@mcp-b/global';
-
-    navigator.modelContext.registerTool({
-      name: "get_page_title",
-      description: "Get the current page title",
-      inputSchema: {
-        type: "object",
-        properties: {}
-      },
-      async execute() {
-        return {
-          content: [{
-            type: "text",
-            text: document.title
-          }]
-        };
-      }
-    });
-    ```
-  </Tab>
-
-  <Tab title="Script Tag (No Build)">
-    No bundler needed - just add a script tag:
-
-    ```html
-    <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
-    <script>
-      navigator.modelContext.registerTool({
-        name: "get_page_title",
-        description: "Get the current page title",
-        inputSchema: { type: "object", properties: {} },
-        async execute() {
-          return {
-            content: [{ type: "text", text: document.title }]
-          };
-        }
-      });
-    </script>
-    ```
-  </Tab>
-</Tabs>
-
-That's it! Your tools are now discoverable by AI agents.
-
 ## Next Steps
 
-<Steps>
-  <Step title="Understand Core Concepts">
-    Learn about [WebMCP architecture and components](/concepts/architecture)
-  </Step>
-  <Step title="Install the Extension">
-    Get the [MCP-B Chrome Extension](https://chromewebstore.google.com/detail/mcp-b-extension/daohopfhkdelnpemnhlekblhnikhdhfa)
-  </Step>
-  <Step title="Follow the Quickstart">
-    Set up WebMCP on your website in the [Quick Start Guide](/quickstart)
-  </Step>
-  <Step title="Review Security">
-    Understand [security best practices](/security) before deploying
-  </Step>
-  <Step title="Explore Examples">
-    Check out [working examples](/examples) for different frameworks
-  </Step>
-  <Step title="Build Your Integration">
-    Use our [NPM packages](/packages/global) to create custom tools
-  </Step>
-</Steps>
+<CardGroup cols={2}>
+  <Card title="Quick Start" icon="rocket" href="/quickstart">
+    Get WebMCP running on your website in minutes
+  </Card>
+
+  <Card title="Core Concepts" icon="diagram-project" href="/concepts/overview">
+    Understand the architecture and how components work together
+  </Card>
+
+  <Card title="Examples" icon="code" href="/examples">
+    Explore ready-to-use examples for React, Vue, and vanilla JS
+  </Card>
+
+  <Card title="Security Guide" icon="shield-halved" href="/security">
+    Security best practices before deploying
+  </Card>
+</CardGroup>
 
 ## Understanding the Standards
 
 WebMCP builds on the Model Context Protocol (MCP), adapting it for the web platform:
 
 <CardGroup cols={2}>
-  <Card title="WebMCP Specification" icon="w3c" href="https://github.com/webmachinelearning/webmcp">
-    W3C Web Model Context API proposal and technical specification
-  </Card>
-  <Card title="WebMCP Proposal" icon="file-lines" href="https://github.com/webmachinelearning/webmcp/blob/main/docs/proposal.md">
-    Detailed proposal with API design and examples
+  <Card title="WebMCP Specification" icon="globe" href="https://github.com/webmachinelearning/webmcp">
+    W3C Web Model Context API proposal
   </Card>
   <Card title="MCP Documentation" icon="book" href="https://modelcontextprotocol.io">
-    Learn about the original Model Context Protocol specification
-  </Card>
-  <Card title="MCP GitHub" icon="github" href="https://github.com/modelcontextprotocol">
-    Explore Anthropic's official MCP repositories and SDK
+    Original Model Context Protocol specification
   </Card>
 </CardGroup>
 
-
-## Related Resources
+## Community
 
 <CardGroup cols={3}>
-  <Card title="Core Concepts" icon="diagram-project" href="/concepts/overview">
-    Architecture overview and diagrams
+  <Card title="Discord" icon="discord" href="https://discord.gg/ZnHG4csJRB">
+    Get help and discuss ideas
   </Card>
-
-  <Card title="Glossary" icon="book" href="/concepts/glossary">
-    Key terminology reference
+  <Card title="GitHub" icon="github" href="https://github.com/WebMCP-org">
+    Explore the source code
   </Card>
-
-  <Card title="Security Guide" icon="shield-halved" href="/security">
-    Security best practices
-  </Card>
-
-  <Card title="Changelog" icon="clock-rotate-left" href="/changelog">
-    Version history and migrations
-  </Card>
-
-  <Card title="Troubleshooting" icon="wrench" href="/troubleshooting">
-    Common issues and solutions
-  </Card>
-
-  <Card title="Extension Guide" icon="puzzle-piece" href="/extension/index">
-    MCP-B browser extension docs
+  <Card title="NPM" icon="npm" href="https://www.npmjs.com/package/@mcp-b/global">
+    Install our packages
   </Card>
 </CardGroup>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -101,23 +101,6 @@ Before you begin, ensure you have:
   </Tab>
 </Tabs>
 
-## Building Interactive Apps with MCP-UI + WebMCP
-
-Want to build interactive apps that AI agents can control? Use `create-webmcp-app`:
-
-```bash icon="terminal"
-npx create-webmcp-app
-cd your-project
-pnpm dev
-```
-
-This scaffolds a complete system:
-- **MCP Server** (Cloudflare Workers) - Exposes tools to AI
-- **Embedded App** (React or Vanilla) - Runs in iframe, registers tools
-- **Bidirectional Communication** - AI controls your app, your app notifies AI
-
-See the [Building MCP-UI Apps guide](/building-mcp-ui-apps) for the complete walkthrough.
-
 ## Real-World Example
 
 Wrap your existing application logic as tools:
@@ -222,55 +205,16 @@ Wrap your existing application logic as tools:
   </Card>
 </CardGroup>
 
-## Best Practices
+## Quick Tips
 
-<AccordionGroup>
-  <Accordion title="✅ Use registerTool() - it just works!">
-    For 99% of use cases, use `navigator.modelContext.registerTool()`. It's simple, automatic, and handles cleanup for you.
+- **Security**: Only expose tools users can already access via your UI. Tools inherit user authentication.
+- **Naming**: Use descriptive names like `add_to_cart`, `search_products`, `update_profile`
+- **Validation**: Always define input schemas - use Zod (React) or JSON Schema (vanilla)
+- **Feedback**: Update UI state in handlers so users see what's happening
 
-    ```javascript icon="square-js"
-    const registration = navigator.modelContext.registerTool({
-      name: 'my_tool',
-      description: 'What my tool does',
-      inputSchema: { /* ... */ },
-      async execute(args) { /* ... */ }
-    });
-    ```
-  </Accordion>
-
-  <Accordion title="⚛️ React: Use the useWebMCP() hook">
-    React users should use the `useWebMCP()` hook - it handles registration, cleanup, and Zod validation automatically:
-
-    ```tsx icon="react"
-    useWebMCP({
-      name: 'my_tool',
-      description: 'What it does',
-      inputSchema: { amount: z.number() },
-      handler: async ({ amount }) => { /* ... */ }
-    });
-    ```
-  </Accordion>
-
-  <Accordion title="🔒 Security first">
-    - Only expose tools users can already access via your UI
-    - Validate all inputs with schemas
-    - Use `credentials: 'same-origin'` for API calls
-    - Tools inherit the user's authentication and permissions
-  </Accordion>
-
-  <Accordion title="🎨 Tool design tips">
-    - Use descriptive names: `add_to_cart`, `search_products`, `update_profile`
-    - Wrap existing functions - don't duplicate logic
-    - Provide visual feedback when tools execute
-    - Return clear success/error messages
-  </Accordion>
-
-  <Accordion title="⚠️ When to use provideContext()">
-    Only use `provideContext()` for defining base application-level tools. Most developers should stick with `registerTool()`.
-
-    See [Advanced Patterns](/advanced#context-engineering-patterns) for details.
-  </Accordion>
-</AccordionGroup>
+<Info>
+  See [Best Practices](/best-practices) for comprehensive guidance on tool design and security.
+</Info>
 
 ## Next Steps
 


### PR DESCRIPTION
- Remove duplicate "Quick Example" from introduction (already in quickstart)
- Consolidate two "Next Steps" sections into one focused section
- Remove duplicate sentence about discoverable tools
- Move MCP-UI section out of quickstart to reduce cognitive load
- Replace verbose best practices accordions with quick tips
- Streamline concepts/overview to focus on core concepts without
  repeating introduction content
- Reduce overall content by ~200 lines while improving clarity