### PR TITLE
docs: add early incubation disclaimer to key pages

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -6,6 +6,10 @@ icon: 'book-open'
 
 ## Welcome to WebMCP
 
+<Warning>
+**Early Incubation**: The WebMCP API is currently being incubated by the [W3C Web Machine Learning Community Group](https://www.w3.org/community/webmachinelearning/). The standard is still evolving, and not all features implemented by MCP-B may be included in the final WebMCP specification. APIs and patterns documented here are subject to change as the standard matures.
+</Warning>
+
 With WebMCP, your existing JavaScript functions become discoverable tools. Rather than relying on browser automation or remote APIs, agents get deterministic function calls that work reliably and securely.
 
 ### The Problem

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -25,6 +25,10 @@ Before you begin, ensure you have:
 - **Node.js 18+** (for NPM installation) or basic HTML knowledge (for script tag method)
 - **Package manager**: npm, pnpm, or yarn (optional for NPM method)
 
+<Note>
+**Early Incubation**: WebMCP is being incubated by the W3C Web Machine Learning Community Group. Not all MCP-B features may be included in the final WebMCP specification. See the [introduction](/introduction) for details.
+</Note>
+
 ## Installation
 
 <Tabs>


### PR DESCRIPTION
Add prominent warnings to introduction and quickstart pages clarifying
that WebMCP is in early incubation by the W3C Web Machine Learning
Community Group, and that MCP-B features may not all be included in
the final WebMCP specification.