### PR TITLE
docs: remove redundant content across documentation pages

### DIFF
--- a/advanced.mdx
+++ b/advanced.mdx
@@ -60,33 +60,10 @@ function ProductPage({ productId }) {
 }
 ```
 
-### Component Lifecycle Tool Scoping
-
-Tools automatically register when mounted and unregister when unmounted:
-
-```tsx
-function CartTools({ cartId, items }) {
-  useWebMCP({
-    name: 'checkout',
-    description: 'Proceed to checkout',
-    inputSchema: { paymentMethod: z.enum(['credit', 'debit', 'paypal']) },
-    handler: async ({ paymentMethod }) => {
-      const order = await checkoutService.processCart(cartId, paymentMethod);
-      return { orderId: order.id };
-    },
-    enabled: items.length > 0 // Only available when cart has items
-  });
-
-  return null;
-}
-```
-
-This creates a **UI for LLMs** - instead of showing all tools at once, you progressively reveal capabilities based on context.
-
-## Context Engineering Patterns
+## Context Engineering
 
 <Note>
-For comprehensive context engineering patterns including URL-based scoping, progressive disclosure, role-based tools, and feature flags, see the dedicated [Context Engineering](/concepts/context-engineering) concept guide.
+For comprehensive context engineering patterns including URL-based scoping, progressive disclosure, role-based tools, component lifecycle scoping, and feature flags, see the dedicated [Context Engineering](/concepts/context-engineering) guide.
 </Note>
 
 The key principle: limit tool availability based on application state to reduce AI model confusion and improve decision quality. Use the `enabled` prop on `useWebMCP` to conditionally register tools.

--- a/best-practices.mdx
+++ b/best-practices.mdx
@@ -471,88 +471,13 @@ if (rateLimitExceeded) {
 For comprehensive security guidance including authentication, authorization, input validation, prompt injection protection, and multi-website threat models, see the dedicated [Security Guide](/security).
 </Note>
 
-Key security principles for WebMCP tools:
-
-- **Validate user authentication** - Always verify session and permissions
-- **Sanitize inputs** - Use DOMPurify for HTML, parameterized queries for databases
-- **Rate limit operations** - Protect against abuse with request throttling
-- **Limit data exposure** - Only return necessary fields, never expose sensitive data
-- **Use tool annotations** - Mark destructive operations with `destructiveHint: true`
-
 ## Performance Optimization
 
-### Design for Async Operations
+<Note>
+For comprehensive performance guidelines including tool registration patterns, tool limits, lazy registration, timeouts, and memory management, see the [Performance Guidelines](/concepts/performance).
+</Note>
 
-All tool execution should be non-blocking:
-
-```javascript
-// ✅ Async with proper error handling, markdown formatted
-async execute({ query }) {
-  try {
-    const [products, categories, suggestions] = await Promise.all([
-      searchProducts(query),
-      getCategories(),
-      getSuggestions(query)
-    ]);
-
-    return {
-      content: [{
-        type: "text",
-        text: `# Search Results
-
-## Products
-${products.map(p => `- **${p.name}** - $${p.price}`).join('\n')}
-
-## Available Categories
-${categories.join(', ')}
-
-## Did you mean?
-${suggestions.join(', ')}`
-      }]
-    };
-  } catch (error) {
-    return formatError('SERVER_ERROR', error.message);
-  }
-}
-```
-
-### Implement Timeouts
-
-Prevent tools from hanging indefinitely:
-
-```javascript
-const TIMEOUT = 5000; // 5 seconds
-
-async execute({ query }) {
-  try {
-    const results = await Promise.race([
-      performSearch(query),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Timeout')), TIMEOUT)
-      )
-    ]);
-
-    return {
-      content: [{
-        type: "text",
-        text: `# Search Results for "${query}"
-
-${results.map((r, i) => `${i + 1}. ${r.title}`).join('\n')}`
-      }]
-    };
-  } catch (error) {
-    if (error.message === 'Timeout') {
-      return formatError(
-        'TIMEOUT',
-        'Search took too long. Please try a more specific query.'
-      );
-    }
-    throw error;
-  }
-}
-```
-
-### Use Optimistic Updates for Voice Models
+### Optimistic Updates for Voice Models
 
 Voice models and real-time interactions work best with instant tool responses. Implement optimistic updates by operating on in-app state rather than waiting for async API calls:
 
@@ -633,36 +558,6 @@ ${cartItems.map(item => `- ${item.name} x${item.quantity} - $${item.price * item
 - Update state synchronously before returning from tool
 - Queue background sync operations
 - Handle sync failures gracefully with retry logic
-
-### Limit Response Size
-
-Prevent sending huge payloads:
-
-```javascript
-const MAX_RESULTS = 100;
-const MAX_RESPONSE_SIZE = 1024 * 100; // 100KB
-
-async execute({ query, limit = 10 }) {
-  const safLimit = Math.min(limit, MAX_RESULTS);
-  const results = await search(query, safLimit);
-
-  // Format as markdown
-  const markdown = `# Search Results for "${query}"
-
-Found ${results.length} results:
-
-${results.map((r, i) => `${i + 1}. **${r.title}**\n   ${r.description}`).join('\n\n')}`;
-
-  if (markdown.length > MAX_RESPONSE_SIZE) {
-    return formatError(
-      'RESPONSE_TOO_LARGE',
-      `Response exceeds maximum size. Try reducing limit (current: ${safLimit}).`
-    );
-  }
-
-  return { content: [{ type: "text", text: markdown }] };
-}
-```
 
 ## Testing & Quality Assurance
 

--- a/concepts/tool-design.mdx
+++ b/concepts/tool-design.mdx
@@ -1,139 +1,55 @@
 ---
 title: 'Tool Design Quick Reference'
-description: 'Quick reference for WebMCP tool design patterns. For detailed guidance, see Best Practices.'
+description: 'Quick reference checklist for WebMCP tool design. For detailed guidance with code examples, see Best Practices.'
 icon: 'lightbulb'
 ---
 
 <Note>
-This is a quick reference. For comprehensive guidance with code examples, see [Best Practices for Creating Tools](/best-practices).
+This is a quick reference checklist. For comprehensive guidance with code examples, see [Best Practices for Creating Tools](/best-practices).
 </Note>
 
-## Naming Conventions
+## Design Checklist
 
-Use `domain_verb_noun` pattern with clear, descriptive names:
+| Aspect | Guideline | Details |
+|--------|-----------|---------|
+| **Name** | `domain_verb_noun` pattern | `products_search`, `cart_add_item`, `user_get_profile` |
+| **Description** | Detailed, includes when to use | What it does, return format, prerequisites, if it changes tool list |
+| **Parameters** | Minimal required, clear names | Use `.describe()` on every parameter, use enums for fixed choices |
+| **Response** | Markdown format | Easier for AI to parse and present than JSON |
+| **Errors** | Structured with error codes | `**Error (CODE):** message` format with `isError: true` |
+| **Annotations** | Mark behavior hints | `destructiveHint`, `idempotentHint`, `readOnlyHint` |
+| **Scope** | User workflows, not internal architecture | Balance granularity - not too fine, not too coarse |
 
-```javascript
-// ✅ Good
-"products_search"
-"cart_add_item"
-"user_get_profile"
+## Naming Examples
 
-// ❌ Avoid
-"doStuff"
-"action1"
-"helper"
-```
+| ✅ Good | ❌ Avoid |
+|---------|----------|
+| `products_search` | `doStuff` |
+| `cart_add_item` | `action1` |
+| `user_get_profile` | `helper` |
+| `orders_list_recent` | `processData` |
 
-## Descriptions
+## Tool Scope Guide
 
-Tool descriptions go directly to the AI model's context. Include:
+| Level | Example | Assessment |
+|-------|---------|------------|
+| Too granular | `user_set_first_name`, `user_set_last_name` | Too many tools |
+| Just right | `user_update_profile` | Reasonable grouping |
+| Too coarse | `manage_everything` | Does too much |
 
-- What the tool does and when to use it
-- What data it returns and in what format
-- Prerequisites or dependencies on other tools
-- If execution changes the available tool list
+## Annotations Reference
 
-## Input Schema
-
-<AccordionGroup>
-  <Accordion title="Clear parameter names">
-    Use self-documenting names: `productId`, `quantity`, `addGiftWrap` instead of `id`, `n`, `flag`
-  </Accordion>
-
-  <Accordion title="Minimal required parameters">
-    Only require what's absolutely necessary. Use defaults for optional parameters.
-  </Accordion>
-
-  <Accordion title="Use enums for fixed choices">
-    ```javascript
-    status: { type: "string", enum: ["pending", "approved", "rejected"] }
-    ```
-  </Accordion>
-
-  <Accordion title="Include examples in descriptions">
-    ```javascript
-    dateRange: {
-      type: "string",
-      description: "Format: YYYY-MM-DD/YYYY-MM-DD (e.g., 2024-01-01/2024-01-31)"
-    }
-    ```
-  </Accordion>
-</AccordionGroup>
-
-## Response Format
-
-Return markdown instead of JSON for better AI comprehension:
-
-```javascript
-// ✅ Markdown - easier for AI to present
-return {
-  content: [{
-    type: "text",
-    text: `# Search Results\n\nFound ${count} products:\n\n${items.map(p => `- **${p.name}** - $${p.price}`).join('\n')}`
-  }]
-};
-
-// ❌ JSON - harder for AI to parse and present
-return {
-  content: [{
-    type: "text",
-    text: JSON.stringify({ success: true, products: items })
-  }]
-};
-```
-
-## Tool Annotations
-
-Mark tool behavior for AI agents:
-
-```javascript
-annotations: {
-  destructiveHint: true,    // Irreversible action (delete, purchase)
-  idempotentHint: true,     // Safe to call multiple times
-  readOnlyHint: true        // Only reads data, no modifications
-}
-```
-
-## Error Handling
-
-Always return structured errors with clear messages:
-
-```javascript
-if (!user) {
-  return {
-    content: [{
-      type: "text",
-      text: "**Error (USER_NOT_FOUND):** No user found with that ID"
-    }],
-    isError: true
-  };
-}
-```
-
-## Tool Scope
-
-Design tools around user workflows, not internal architecture. Balance between:
-
-- **Too granular**: `user_set_first_name`, `user_set_last_name` (too many tools)
-- **Just right**: `user_update_profile` (reasonable grouping)
-- **Too coarse**: `manage_everything` (does too much)
-
-## Quick Checklist
-
-| Aspect | Guideline |
-|--------|-----------|
-| **Name** | `domain_verb_noun` pattern |
-| **Description** | Detailed, includes when to use |
-| **Parameters** | Minimal required, clear names, use `.describe()` |
-| **Response** | Markdown format, include context |
-| **Errors** | Structured with error codes |
-| **Annotations** | Mark destructive/readonly operations |
+| Annotation | Use When |
+|------------|----------|
+| `destructiveHint: true` | Irreversible actions (delete, purchase) |
+| `idempotentHint: true` | Safe to call multiple times with same result |
+| `readOnlyHint: true` | Only reads data, no modifications |
 
 ## Related Topics
 
 <CardGroup cols={2}>
   <Card title="Best Practices" icon="star" href="/best-practices">
-    Complete guide with detailed examples
+    Complete guide with detailed code examples
   </Card>
 
   <Card title="Tool Schemas" icon="file-contract" href="/concepts/schemas">


### PR DESCRIPTION
- Remove duplicated CartTools example from advanced.mdx (kept in context-engineering.mdx)
- Simplify context engineering section in advanced.mdx to reference-only
- Streamline tool-design.mdx to true quick-reference with tables instead of code examples
- Remove security bullet points from best-practices.mdx (now link-only to security.mdx)
- Remove duplicated performance patterns from best-practices.mdx (keep unique optimistic updates content)

Reduces 250 lines of redundant documentation while preserving all unique content.