### PR TITLE
docs: add Chrome DevTools MCP documentation

### DIFF
--- a/connecting-agents.mdx
+++ b/connecting-agents.mdx
@@ -322,35 +322,49 @@ Jason's WebMCP is an independent implementation, separate from the MCP-B project
 - Users who prefer not to use browser extensions
 - Custom MCP client integrations
 
-#### Method 3: Chrome DevTools Protocol (Coming Soon)
+#### Method 3: Chrome DevTools MCP
 
-The MCP-B team is developing a custom Chrome DevTools Protocol (CDP) transport for connecting MCP clients directly to the browser.
+`@mcp-b/chrome-devtools-mcp` connects MCP clients directly to Chrome using the Chrome DevTools Protocol, with full WebMCP integration.
 
-<Warning>
-**Status:** In development, not yet available for production use
-</Warning>
+<Card title="Chrome DevTools MCP" icon="chrome" href="/packages/chrome-devtools-mcp">
+  Complete setup guide and documentation
+</Card>
 
-**How it will work:**
+**How it works:**
 ```mermaid
 graph LR
-    A[MCP Client] -->|CDP Transport| B[Chrome Browser]
-    B -->|DevTools Protocol| C[Website Tools]
+    A[MCP Client] -->|Chrome DevTools Protocol| B[Chrome Browser]
+    B -->|WebMCP Bridge| C[Website Tools]
 ```
 
-**Advantages when available:**
-- Direct browser connection without extension
-- Access to browser debugging APIs
-- Lower latency than HTTP bridge
-- More granular control over browser state
+**Quick setup:**
 
-**Use cases:**
-- Advanced automation scenarios
+<Steps>
+  <Step title="Add to your MCP client">
+    ```bash
+    claude mcp add chrome-devtools npx @mcp-b/chrome-devtools-mcp@latest
+    ```
+  </Step>
+
+  <Step title="Test the connection">
+    Ask your AI agent:
+    ```
+    Navigate to http://localhost:3000 and list available WebMCP tools
+    ```
+  </Step>
+</Steps>
+
+**Key features:**
+- Direct browser connection - no extension required
+- Access to 28 browser automation tools
+- WebMCP integration via `list_webmcp_tools` and `call_webmcp_tool`
+- AI-driven development workflow for building and testing tools
+
+**Best for:**
+- AI-driven tool development (build-test loop)
+- Advanced browser automation scenarios
 - Testing and debugging workflows
-- Direct browser control from MCP clients
-
-<Info>
-Watch the [WebMCP GitHub repository](https://github.com/WebMCP-org/npm-packages) for updates on CDP transport availability.
-</Info>
+- Direct browser control from Claude Code, Cursor, Copilot, etc.
 
 ## Choosing the Right Method
 
@@ -415,7 +429,7 @@ Use this guide to select the best connection method for your use case:
 | **MCP-B Extension** | Low | Any website + built-in agents | Yes | No |
 | **Native Server (MCP-B)** | Low | Multiple tabs + extension agents | Yes (MCP-B) | No |
 | **Jason's WebMCP** | Medium | Direct site-to-client | No | Yes (widget script) |
-| **CDP Transport** | TBD | Advanced automation | TBD | No |
+| **Chrome DevTools MCP** | Low | AI-driven development, automation | No | No |
 
 ## Security Considerations
 
@@ -492,6 +506,14 @@ Ready to connect your agent? Follow these quick start guides:
     href="/tools/claude-code"
   >
     Use WebMCP tools with Claude Code
+  </Card>
+
+  <Card
+    title="Chrome DevTools MCP"
+    icon="chrome"
+    href="/packages/chrome-devtools-mcp"
+  >
+    AI-driven development and browser automation
   </Card>
 </CardGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -97,6 +97,7 @@
               "packages/global",
               "packages/transports",
               "packages/react-webmcp",
+              "packages/chrome-devtools-mcp",
               "packages/extension-tools",
               "packages/webmcp-ts-sdk",
               "packages/smart-dom-reader"

--- a/packages/chrome-devtools-mcp.mdx
+++ b/packages/chrome-devtools-mcp.mdx
@@ -1,0 +1,378 @@
+---
+title: Chrome DevTools MCP
+description: MCP server for Chrome DevTools - control browsers and build WebMCP tools with AI-driven development workflows
+sidebarTitle: Chrome DevTools MCP
+icon: chrome
+---
+
+MCP server that lets AI agents like Claude, Cursor, Copilot, and Gemini control and debug Chrome browsers via the Model Context Protocol.
+
+`@mcp-b/chrome-devtools-mcp` is a fork of [Google's Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) with **WebMCP integration** - the ability to call MCP tools registered directly on webpages.
+
+<Card title="NPM Package" icon="npm" href="https://www.npmjs.com/package/@mcp-b/chrome-devtools-mcp">
+  View on npm
+</Card>
+
+## Why use this package?
+
+| Feature | Benefit |
+|---------|---------|
+| **28 MCP Tools** | Comprehensive browser control - navigation, input, screenshots, performance, debugging |
+| **WebMCP Integration** | Connect to website-specific AI tools via `@mcp-b/global` |
+| **AI-Driven Development** | Build and test WebMCP tools in a tight feedback loop |
+| **Performance Analysis** | Chrome DevTools-powered performance insights and trace recording |
+| **Works with All MCP Clients** | Claude, Cursor, Copilot, Gemini CLI, VS Code, Windsurf, and more |
+
+## AI-driven development workflow
+
+One of the most powerful features is the **build-test loop** for WebMCP tools. This creates a tight feedback loop where your AI assistant can write, deploy, discover, test, and iterate on tools in real-time.
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    AI Development Feedback Loop                     │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│   1. AI writes WebMCP tool code ──────────────────────────┐        │
+│                                                            │        │
+│   2. Dev server hot-reloads ◄─────────────────────────────┘        │
+│                                                                     │
+│   3. AI opens browser via Chrome DevTools MCP                       │
+│            │                                                        │
+│            ▼                                                        │
+│   4. AI calls list_webmcp_tools to see the new tool                 │
+│            │                                                        │
+│            ▼                                                        │
+│   5. AI calls call_webmcp_tool to test it                           │
+│            │                                                        │
+│            ▼                                                        │
+│   6. AI sees results, iterates if needed ───────► Back to step 1    │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Example: Building a search tool
+
+**Step 1: Ask your AI agent to create the tool**
+
+```
+Create a WebMCP tool called "search_products" that searches our product catalog
+```
+
+**Step 2: The AI writes the code in your app**
+
+```typescript twoslash
+// @noErrors
+import '@mcp-b/global';
+
+navigator.modelContext.registerTool({
+  name: 'search_products',
+  description: 'Search for products by name or category',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      query: { type: 'string' },
+      category: { type: 'string' }
+    },
+    required: ['query']
+  },
+  async execute({ query, category }) {
+    const results = await searchProducts(query, category);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(results) }]
+    };
+  }
+});
+```
+
+**Step 3:** Your dev server hot-reloads
+
+**Step 4: The AI tests it via Chrome DevTools MCP**
+
+```
+Navigate to http://localhost:3000 and list the available tools
+```
+
+The AI sees the new `search_products` tool appear.
+
+**Step 5: The AI calls the tool to verify it works**
+
+```
+Use the search_products tool to search for "headphones"
+```
+
+**Step 6:** If something is wrong, the AI iterates until it works perfectly.
+
+<Info>
+This is like **TDD for AI** - the AI can build and verify its own tools in real-time.
+</Info>
+
+## Installation
+
+Add the following config to your MCP client:
+
+```json "MCP Configuration"
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "@mcp-b/chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+<Note>
+Using `@mcp-b/chrome-devtools-mcp@latest` ensures your MCP client always uses the latest version with WebMCP integration.
+</Note>
+
+### Client-specific setup
+
+<AccordionGroup>
+  <Accordion title="Claude Code">
+    Use the Claude Code CLI:
+    ```bash
+    claude mcp add chrome-devtools npx @mcp-b/chrome-devtools-mcp@latest
+    ```
+  </Accordion>
+
+  <Accordion title="Claude Desktop">
+    Add to your `claude_desktop_config.json`:
+    ```json
+    {
+      "mcpServers": {
+        "chrome-devtools": {
+          "command": "npx",
+          "args": ["-y", "@mcp-b/chrome-devtools-mcp@latest"]
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Cursor">
+    Go to `Cursor Settings` > `MCP` > `New MCP Server` and use the config above.
+
+    Or click to install directly:
+
+    [Install in Cursor](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBtY3AtYi9jaHJvbWUtZGV2dG9vbHMtbWNwQGxhdGVzdCJdfQ%3D%3D)
+  </Accordion>
+
+  <Accordion title="VS Code / Copilot">
+    Use the VS Code CLI:
+    ```bash
+    code --add-mcp '{"name":"@mcp-b/chrome-devtools-mcp","command":"npx","args":["-y","@mcp-b/chrome-devtools-mcp@latest"],"env":{}}'
+    ```
+  </Accordion>
+
+  <Accordion title="Gemini CLI">
+    ```bash
+    gemini mcp add chrome-devtools npx @mcp-b/chrome-devtools-mcp@latest
+    ```
+  </Accordion>
+
+  <Accordion title="Windsurf">
+    Follow the [Windsurf MCP guide](https://docs.windsurf.com/windsurf/cascade/mcp#mcp-config-json) using the standard config.
+  </Accordion>
+</AccordionGroup>
+
+### Test your setup
+
+Enter this prompt in your MCP client:
+
+```
+Check the performance of https://developers.chrome.com
+```
+
+Your MCP client should open the browser and record a performance trace.
+
+## Available tools
+
+The server provides 28 tools across several categories:
+
+<Tabs>
+  <Tab title="Input Automation">
+    | Tool | Description |
+    |------|-------------|
+    | `click` | Click an element |
+    | `drag` | Drag an element |
+    | `fill` | Fill a text input |
+    | `fill_form` | Fill multiple form fields |
+    | `handle_dialog` | Accept/dismiss dialogs |
+    | `hover` | Hover over an element |
+    | `press_key` | Press keyboard keys |
+    | `upload_file` | Upload files to inputs |
+  </Tab>
+
+  <Tab title="Navigation">
+    | Tool | Description |
+    |------|-------------|
+    | `navigate_page` | Navigate to a URL |
+    | `new_page` | Open a new tab |
+    | `close_page` | Close a tab |
+    | `list_pages` | List open tabs |
+    | `select_page` | Switch to a tab |
+    | `wait_for` | Wait for elements/conditions |
+  </Tab>
+
+  <Tab title="Debugging">
+    | Tool | Description |
+    |------|-------------|
+    | `take_screenshot` | Capture page screenshot |
+    | `take_snapshot` | Get DOM snapshot |
+    | `evaluate_script` | Run JavaScript |
+    | `list_console_messages` | Get console logs |
+    | `get_console_message` | Get specific log |
+  </Tab>
+
+  <Tab title="Performance & Network">
+    | Tool | Description |
+    |------|-------------|
+    | `performance_start_trace` | Start recording trace |
+    | `performance_stop_trace` | Stop and analyze trace |
+    | `performance_analyze_insight` | Get performance insights |
+    | `list_network_requests` | List network activity |
+    | `get_network_request` | Get request details |
+  </Tab>
+
+  <Tab title="WebMCP">
+    | Tool | Description |
+    |------|-------------|
+    | `list_webmcp_tools` | List tools registered on the page (auto-connects) |
+    | `call_webmcp_tool` | Call a website's MCP tool (auto-connects) |
+  </Tab>
+</Tabs>
+
+## Built-in prompts
+
+The server includes prompts to guide AI agents through common workflows:
+
+| Prompt | Description |
+|--------|-------------|
+| `webmcp-dev-workflow` | Step-by-step guide for building WebMCP tools with AI |
+| `test-webmcp-tool` | Systematically test tools with edge cases and validation |
+| `debug-webmcp` | Diagnose WebMCP connection and registration issues |
+
+### Using prompts
+
+```
+Use the webmcp-dev-workflow prompt to help me build a search tool
+```
+
+```
+Use the test-webmcp-tool prompt with toolName=search_products
+```
+
+```
+Use the debug-webmcp prompt with url=http://localhost:3000
+```
+
+## WebMCP integration
+
+When a webpage uses [@mcp-b/global](/packages/global) to register MCP tools, `@mcp-b/chrome-devtools-mcp` connects to those tools using the Chrome DevTools Protocol. This bridges your MCP client with website-specific functionality.
+
+### Using website tools
+
+<Steps>
+  <Step title="Navigate to the webpage">
+    ```
+    Navigate to https://example.com/app
+    ```
+  </Step>
+
+  <Step title="List available tools">
+    ```
+    What tools are available on this website?
+    ```
+    The AI uses `list_webmcp_tools` to discover what the website exposes.
+  </Step>
+
+  <Step title="Use the tools">
+    ```
+    Search for "wireless headphones" using the website's search tool
+    ```
+    The AI uses `call_webmcp_tool` to invoke the website's functionality.
+  </Step>
+</Steps>
+
+<Info>
+No explicit connect/disconnect steps needed - WebMCP tools auto-connect when called and reconnect when you navigate.
+</Info>
+
+## Configuration options
+
+Pass options via the `args` property:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "@mcp-b/chrome-devtools-mcp@latest",
+        "--headless=true",
+        "--isolated=true"
+      ]
+    }
+  }
+}
+```
+
+| Option | Description |
+|--------|-------------|
+| `--browserUrl`, `-u` | Connect to running Chrome instance (e.g., `http://127.0.0.1:9222`) |
+| `--headless` | Run without UI (default: `false`) |
+| `--isolated` | Use temporary user data dir, cleaned up on close |
+| `--executablePath`, `-e` | Path to custom Chrome executable |
+| `--channel` | Chrome channel: `stable`, `canary`, `beta`, `dev` |
+| `--viewport` | Initial viewport size (e.g., `1280x720`) |
+
+Run `npx @mcp-b/chrome-devtools-mcp@latest --help` for all options.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="WebMCP not detected">
+    The current webpage doesn't have `@mcp-b/global` installed or no tools are registered. The page needs the WebMCP polyfill loaded.
+  </Accordion>
+
+  <Accordion title="Tool call fails">
+    Check the tool's input schema matches your parameters. Use `list_webmcp_tools` to see the expected input format.
+  </Accordion>
+
+  <Accordion title="Tools not appearing after navigation">
+    WebMCP auto-reconnects when you navigate. If the new page has different tools, call `list_webmcp_tools` again.
+  </Accordion>
+
+  <Accordion title="Browser won't start">
+    Some MCP clients sandbox the server. Either disable sandboxing or use `--browser-url` to connect to a Chrome instance started manually.
+  </Accordion>
+</AccordionGroup>
+
+## Security considerations
+
+<Warning>
+`@mcp-b/chrome-devtools-mcp` exposes browser content to MCP clients, allowing them to inspect, debug, and modify any data. Avoid sharing sensitive or personal information.
+</Warning>
+
+## Related packages
+
+<CardGroup cols={2}>
+  <Card title="@mcp-b/global" icon="globe" href="/packages/global">
+    Web Model Context API polyfill for websites
+  </Card>
+  <Card title="@mcp-b/react-webmcp" icon="react" href="/packages/react-webmcp">
+    React hooks for registering MCP tools
+  </Card>
+  <Card title="@mcp-b/transports" icon="plug" href="/packages/transports">
+    Browser-specific MCP transports
+  </Card>
+  <Card title="Native Server Setup" icon="server" href="/native-host-setup">
+    Connect local MCP clients to browser tools
+  </Card>
+</CardGroup>
+
+## Resources
+
+- [GitHub Repository](https://github.com/WebMCP-org/npm-packages/tree/main/packages/chrome-devtools-mcp)
+- [Tool Reference](https://github.com/WebMCP-org/npm-packages/blob/main/packages/chrome-devtools-mcp/docs/tool-reference.md)
+- [Original Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)

--- a/packages/chrome-devtools-mcp.mdx
+++ b/packages/chrome-devtools-mcp.mdx
@@ -1,114 +1,51 @@
 ---
 title: Chrome DevTools MCP
-description: MCP server for Chrome DevTools - control browsers and build WebMCP tools with AI-driven development workflows
+description: MCP server for Chrome DevTools with WebMCP integration - control browsers and build tools with AI-driven development
 sidebarTitle: Chrome DevTools MCP
 icon: chrome
 ---
 
-MCP server that lets AI agents like Claude, Cursor, Copilot, and Gemini control and debug Chrome browsers via the Model Context Protocol.
-
-`@mcp-b/chrome-devtools-mcp` is a fork of [Google's Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) with **WebMCP integration** - the ability to call MCP tools registered directly on webpages.
+MCP server that lets AI agents control Chrome browsers via the Chrome DevTools Protocol, with WebMCP integration for calling tools registered on webpages.
 
 <Card title="NPM Package" icon="npm" href="https://www.npmjs.com/package/@mcp-b/chrome-devtools-mcp">
-  View on npm
+  @mcp-b/chrome-devtools-mcp
 </Card>
 
-## Why use this package?
+## Key features
 
-| Feature | Benefit |
-|---------|---------|
-| **28 MCP Tools** | Comprehensive browser control - navigation, input, screenshots, performance, debugging |
-| **WebMCP Integration** | Connect to website-specific AI tools via `@mcp-b/global` |
-| **AI-Driven Development** | Build and test WebMCP tools in a tight feedback loop |
-| **Performance Analysis** | Chrome DevTools-powered performance insights and trace recording |
-| **Works with All MCP Clients** | Claude, Cursor, Copilot, Gemini CLI, VS Code, Windsurf, and more |
+- **28 browser automation tools** - navigation, input, screenshots, performance, debugging
+- **WebMCP integration** - call tools registered via [@mcp-b/global](/packages/global)
+- **AI-driven development** - build and test WebMCP tools in a tight feedback loop
+- **Works with all MCP clients** - Claude Code, Cursor, VS Code, Gemini CLI, Windsurf
 
 ## AI-driven development workflow
 
-One of the most powerful features is the **build-test loop** for WebMCP tools. This creates a tight feedback loop where your AI assistant can write, deploy, discover, test, and iterate on tools in real-time.
+The **build-test loop** lets AI agents write, deploy, discover, test, and iterate on WebMCP tools in real-time:
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    AI Development Feedback Loop                     │
-├─────────────────────────────────────────────────────────────────────┤
-│                                                                     │
-│   1. AI writes WebMCP tool code ──────────────────────────┐        │
-│                                                            │        │
-│   2. Dev server hot-reloads ◄─────────────────────────────┘        │
-│                                                                     │
-│   3. AI opens browser via Chrome DevTools MCP                       │
-│            │                                                        │
-│            ▼                                                        │
-│   4. AI calls list_webmcp_tools to see the new tool                 │
-│            │                                                        │
-│            ▼                                                        │
-│   5. AI calls call_webmcp_tool to test it                           │
-│            │                                                        │
-│            ▼                                                        │
-│   6. AI sees results, iterates if needed ───────► Back to step 1    │
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart LR
+    A[AI writes tool] --> B[Dev server hot-reloads]
+    B --> C[AI navigates to page]
+    C --> D[list_webmcp_tools]
+    D --> E[call_webmcp_tool]
+    E --> F{Works?}
+    F -->|No| A
+    F -->|Yes| G[Done]
 ```
 
-### Example: Building a search tool
+**Example workflow:**
 
-**Step 1: Ask your AI agent to create the tool**
-
-```
-Create a WebMCP tool called "search_products" that searches our product catalog
-```
-
-**Step 2: The AI writes the code in your app**
-
-```typescript twoslash
-// @noErrors
-import '@mcp-b/global';
-
-navigator.modelContext.registerTool({
-  name: 'search_products',
-  description: 'Search for products by name or category',
-  inputSchema: {
-    type: 'object',
-    properties: {
-      query: { type: 'string' },
-      category: { type: 'string' }
-    },
-    required: ['query']
-  },
-  async execute({ query, category }) {
-    const results = await searchProducts(query, category);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(results) }]
-    };
-  }
-});
-```
-
-**Step 3:** Your dev server hot-reloads
-
-**Step 4: The AI tests it via Chrome DevTools MCP**
-
-```
-Navigate to http://localhost:3000 and list the available tools
-```
-
-The AI sees the new `search_products` tool appear.
-
-**Step 5: The AI calls the tool to verify it works**
-
-```
-Use the search_products tool to search for "headphones"
-```
-
-**Step 6:** If something is wrong, the AI iterates until it works perfectly.
+1. Ask AI: *"Create a WebMCP tool called search_products"*
+2. AI writes tool using [registerTool()](/concepts/tool-registration)
+3. Dev server hot-reloads
+4. AI navigates to `http://localhost:3000`, discovers and tests the tool
+5. AI iterates until it works
 
 <Info>
-This is like **TDD for AI** - the AI can build and verify its own tools in real-time.
+This is **TDD for AI** - agents build and verify their own tools in real-time.
 </Info>
 
 ## Installation
-
-Add the following config to your MCP client:
 
 ```json "MCP Configuration"
 {
@@ -121,46 +58,20 @@ Add the following config to your MCP client:
 }
 ```
 
-<Note>
-Using `@mcp-b/chrome-devtools-mcp@latest` ensures your MCP client always uses the latest version with WebMCP integration.
-</Note>
-
-### Client-specific setup
-
 <AccordionGroup>
   <Accordion title="Claude Code">
-    Use the Claude Code CLI:
     ```bash
     claude mcp add chrome-devtools npx @mcp-b/chrome-devtools-mcp@latest
     ```
   </Accordion>
 
-  <Accordion title="Claude Desktop">
-    Add to your `claude_desktop_config.json`:
-    ```json
-    {
-      "mcpServers": {
-        "chrome-devtools": {
-          "command": "npx",
-          "args": ["-y", "@mcp-b/chrome-devtools-mcp@latest"]
-        }
-      }
-    }
-    ```
-  </Accordion>
-
   <Accordion title="Cursor">
-    Go to `Cursor Settings` > `MCP` > `New MCP Server` and use the config above.
-
-    Or click to install directly:
-
     [Install in Cursor](https://cursor.com/en/install-mcp?name=chrome-devtools&config=eyJjb21tYW5kIjoibnB4IiwiYXJncyI6WyIteSIsIkBtY3AtYi9jaHJvbWUtZGV2dG9vbHMtbWNwQGxhdGVzdCJdfQ%3D%3D)
   </Accordion>
 
   <Accordion title="VS Code / Copilot">
-    Use the VS Code CLI:
     ```bash
-    code --add-mcp '{"name":"@mcp-b/chrome-devtools-mcp","command":"npx","args":["-y","@mcp-b/chrome-devtools-mcp@latest"],"env":{}}'
+    code --add-mcp '{"name":"chrome-devtools","command":"npx","args":["-y","@mcp-b/chrome-devtools-mcp@latest"]}'
     ```
   </Accordion>
 
@@ -169,210 +80,75 @@ Using `@mcp-b/chrome-devtools-mcp@latest` ensures your MCP client always uses th
     gemini mcp add chrome-devtools npx @mcp-b/chrome-devtools-mcp@latest
     ```
   </Accordion>
-
-  <Accordion title="Windsurf">
-    Follow the [Windsurf MCP guide](https://docs.windsurf.com/windsurf/cascade/mcp#mcp-config-json) using the standard config.
-  </Accordion>
 </AccordionGroup>
 
-### Test your setup
+**Test:** Ask your AI to *"Check the performance of https://developers.chrome.com"*
 
-Enter this prompt in your MCP client:
-
-```
-Check the performance of https://developers.chrome.com
-```
-
-Your MCP client should open the browser and record a performance trace.
-
-## Available tools
-
-The server provides 28 tools across several categories:
+## Tools
 
 <Tabs>
-  <Tab title="Input Automation">
-    | Tool | Description |
-    |------|-------------|
-    | `click` | Click an element |
-    | `drag` | Drag an element |
-    | `fill` | Fill a text input |
-    | `fill_form` | Fill multiple form fields |
-    | `handle_dialog` | Accept/dismiss dialogs |
-    | `hover` | Hover over an element |
-    | `press_key` | Press keyboard keys |
-    | `upload_file` | Upload files to inputs |
-  </Tab>
-
-  <Tab title="Navigation">
-    | Tool | Description |
-    |------|-------------|
-    | `navigate_page` | Navigate to a URL |
-    | `new_page` | Open a new tab |
-    | `close_page` | Close a tab |
-    | `list_pages` | List open tabs |
-    | `select_page` | Switch to a tab |
-    | `wait_for` | Wait for elements/conditions |
-  </Tab>
-
-  <Tab title="Debugging">
-    | Tool | Description |
-    |------|-------------|
-    | `take_screenshot` | Capture page screenshot |
-    | `take_snapshot` | Get DOM snapshot |
-    | `evaluate_script` | Run JavaScript |
-    | `list_console_messages` | Get console logs |
-    | `get_console_message` | Get specific log |
-  </Tab>
-
-  <Tab title="Performance & Network">
-    | Tool | Description |
-    |------|-------------|
-    | `performance_start_trace` | Start recording trace |
-    | `performance_stop_trace` | Stop and analyze trace |
-    | `performance_analyze_insight` | Get performance insights |
-    | `list_network_requests` | List network activity |
-    | `get_network_request` | Get request details |
-  </Tab>
-
   <Tab title="WebMCP">
     | Tool | Description |
     |------|-------------|
-    | `list_webmcp_tools` | List tools registered on the page (auto-connects) |
-    | `call_webmcp_tool` | Call a website's MCP tool (auto-connects) |
+    | `list_webmcp_tools` | Discover tools registered on the current page |
+    | `call_webmcp_tool` | Call a website's MCP tool |
+  </Tab>
+
+  <Tab title="Input">
+    `click`, `drag`, `fill`, `fill_form`, `handle_dialog`, `hover`, `press_key`, `upload_file`
+  </Tab>
+
+  <Tab title="Navigation">
+    `navigate_page`, `new_page`, `close_page`, `list_pages`, `select_page`, `wait_for`
+  </Tab>
+
+  <Tab title="Debugging">
+    `take_screenshot`, `take_snapshot`, `evaluate_script`, `list_console_messages`, `get_console_message`
+  </Tab>
+
+  <Tab title="Performance">
+    `performance_start_trace`, `performance_stop_trace`, `performance_analyze_insight`, `list_network_requests`, `get_network_request`
   </Tab>
 </Tabs>
 
 ## Built-in prompts
 
-The server includes prompts to guide AI agents through common workflows:
+| Prompt | Use case |
+|--------|----------|
+| `webmcp-dev-workflow` | Guide through building WebMCP tools |
+| `test-webmcp-tool` | Test tools with edge cases |
+| `debug-webmcp` | Diagnose connection issues |
 
-| Prompt | Description |
-|--------|-------------|
-| `webmcp-dev-workflow` | Step-by-step guide for building WebMCP tools with AI |
-| `test-webmcp-tool` | Systematically test tools with edge cases and validation |
-| `debug-webmcp` | Diagnose WebMCP connection and registration issues |
-
-### Using prompts
-
-```
-Use the webmcp-dev-workflow prompt to help me build a search tool
-```
-
-```
-Use the test-webmcp-tool prompt with toolName=search_products
-```
-
-```
-Use the debug-webmcp prompt with url=http://localhost:3000
-```
-
-## WebMCP integration
-
-When a webpage uses [@mcp-b/global](/packages/global) to register MCP tools, `@mcp-b/chrome-devtools-mcp` connects to those tools using the Chrome DevTools Protocol. This bridges your MCP client with website-specific functionality.
-
-### Using website tools
-
-<Steps>
-  <Step title="Navigate to the webpage">
-    ```
-    Navigate to https://example.com/app
-    ```
-  </Step>
-
-  <Step title="List available tools">
-    ```
-    What tools are available on this website?
-    ```
-    The AI uses `list_webmcp_tools` to discover what the website exposes.
-  </Step>
-
-  <Step title="Use the tools">
-    ```
-    Search for "wireless headphones" using the website's search tool
-    ```
-    The AI uses `call_webmcp_tool` to invoke the website's functionality.
-  </Step>
-</Steps>
-
-<Info>
-No explicit connect/disconnect steps needed - WebMCP tools auto-connect when called and reconnect when you navigate.
-</Info>
-
-## Configuration options
-
-Pass options via the `args` property:
-
-```json
-{
-  "mcpServers": {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": [
-        "@mcp-b/chrome-devtools-mcp@latest",
-        "--headless=true",
-        "--isolated=true"
-      ]
-    }
-  }
-}
-```
+## Configuration
 
 | Option | Description |
 |--------|-------------|
-| `--browserUrl`, `-u` | Connect to running Chrome instance (e.g., `http://127.0.0.1:9222`) |
-| `--headless` | Run without UI (default: `false`) |
-| `--isolated` | Use temporary user data dir, cleaned up on close |
-| `--executablePath`, `-e` | Path to custom Chrome executable |
+| `--browserUrl` | Connect to running Chrome (e.g., `http://127.0.0.1:9222`) |
+| `--headless` | Run without UI |
+| `--isolated` | Use temporary profile, cleaned up on close |
 | `--channel` | Chrome channel: `stable`, `canary`, `beta`, `dev` |
-| `--viewport` | Initial viewport size (e.g., `1280x720`) |
 
 Run `npx @mcp-b/chrome-devtools-mcp@latest --help` for all options.
 
 ## Troubleshooting
 
-<AccordionGroup>
-  <Accordion title="WebMCP not detected">
-    The current webpage doesn't have `@mcp-b/global` installed or no tools are registered. The page needs the WebMCP polyfill loaded.
-  </Accordion>
-
-  <Accordion title="Tool call fails">
-    Check the tool's input schema matches your parameters. Use `list_webmcp_tools` to see the expected input format.
-  </Accordion>
-
-  <Accordion title="Tools not appearing after navigation">
-    WebMCP auto-reconnects when you navigate. If the new page has different tools, call `list_webmcp_tools` again.
-  </Accordion>
-
-  <Accordion title="Browser won't start">
-    Some MCP clients sandbox the server. Either disable sandboxing or use `--browser-url` to connect to a Chrome instance started manually.
-  </Accordion>
-</AccordionGroup>
-
-## Security considerations
+| Issue | Solution |
+|-------|----------|
+| WebMCP not detected | Page needs [@mcp-b/global](/packages/global) loaded |
+| Tool call fails | Check input matches schema via `list_webmcp_tools` |
+| Browser won't start | Disable client sandboxing or use `--browserUrl` |
 
 <Warning>
-`@mcp-b/chrome-devtools-mcp` exposes browser content to MCP clients, allowing them to inspect, debug, and modify any data. Avoid sharing sensitive or personal information.
+This server exposes browser content to MCP clients. Avoid sensitive data.
 </Warning>
 
-## Related packages
+## Related
 
 <CardGroup cols={2}>
   <Card title="@mcp-b/global" icon="globe" href="/packages/global">
-    Web Model Context API polyfill for websites
+    Register tools on your website
   </Card>
-  <Card title="@mcp-b/react-webmcp" icon="react" href="/packages/react-webmcp">
-    React hooks for registering MCP tools
-  </Card>
-  <Card title="@mcp-b/transports" icon="plug" href="/packages/transports">
-    Browser-specific MCP transports
-  </Card>
-  <Card title="Native Server Setup" icon="server" href="/native-host-setup">
-    Connect local MCP clients to browser tools
+  <Card title="Tool Registration" icon="screwdriver-wrench" href="/concepts/tool-registration">
+    How to write WebMCP tools
   </Card>
 </CardGroup>
-
-## Resources
-
-- [GitHub Repository](https://github.com/WebMCP-org/npm-packages/tree/main/packages/chrome-devtools-mcp)
-- [Tool Reference](https://github.com/WebMCP-org/npm-packages/blob/main/packages/chrome-devtools-mcp/docs/tool-reference.md)
-- [Original Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp)


### PR DESCRIPTION
- Add comprehensive documentation page for @mcp-b/chrome-devtools-mcp package
- Document AI-driven development workflow (build-test loop) for WebMCP tools
- Include installation guides for Claude Code, Cursor, VS Code, and other clients
- Add tool reference and WebMCP integration sections
- Update connecting-agents.mdx to reflect chrome-devtools-mcp availability
- Update comparison matrix and add getting started card
- Add chrome-devtools-mcp to NPM Packages navigation in docs.json