### PR TITLE
fix: correct dead links in documentation

### DIFF
--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -147,7 +147,7 @@ sequenceDiagram
     Deep dive into the MCP-B extension
   </Card>
 
-  <Card title="Security Model" icon="shield" href="/concepts/security">
+  <Card title="Security Model" icon="shield" href="/security">
     How WebMCP maintains security
   </Card>
 </CardGroup>

--- a/examples.mdx
+++ b/examples.mdx
@@ -57,7 +57,7 @@ icon: 'code'
   <Card
     title="create-webmcp-app"
     icon="rocket"
-    href="https://github.com/WebMCP-org/mcp-ui-webmcp/tree/main/create-webmcp-app"
+    href="https://github.com/WebMCP-org/mcp-ui-webmcp/tree/main/apps/create-webmcp-app"
   >
     Interactive CLI to scaffold MCP-UI + WebMCP apps (Vanilla or React)
   </Card>
@@ -65,7 +65,7 @@ icon: 'code'
   <Card
     title="Vanilla Template"
     icon="js"
-    href="https://github.com/WebMCP-org/mcp-ui-webmcp/tree/main/webmcp-template-vanilla"
+    href="https://github.com/WebMCP-org/mcp-ui-webmcp/tree/main/templates/vanilla"
   >
     Pure HTML/CSS/JavaScript template with no build step required
   </Card>
@@ -92,33 +92,17 @@ See the [Building MCP-UI Apps guide](/building-mcp-ui-apps) for complete documen
   <Card
     title="Vanilla TypeScript"
     icon="js"
-    href="https://github.com/WebMCP-org/examples/tree/main/vanilla-ts"
+    href="https://github.com/WebMCP-org/examples/tree/main/vanilla"
   >
     Simple todo app demonstrating core concepts with navigator.modelContext
   </Card>
 
   <Card
-    title="Script Tag"
-    icon="code"
-    href="https://github.com/WebMCP-org/examples/tree/main/script-tag"
+    title="React Task Manager"
+    icon="react"
+    href="https://github.com/WebMCP-org/examples/tree/main/react"
   >
-    No build tools required - just add a script tag for W3C API
-  </Card>
-
-  <Card
-    title="React Flow Voice Agent"
-    icon="microphone"
-    href="https://github.com/WebMCP-org/examples/tree/main/reactFlowVoiceAgent"
-  >
-    Advanced React app with voice input and visual flow
-  </Card>
-
-  <Card
-    title="Login Flow"
-    icon="lock"
-    href="https://github.com/WebMCP-org/examples/tree/main/login"
-  >
-    Authentication and session management with WebMCP
+    Task management app demonstrating React integration via useWebMCP() hook
   </Card>
 </CardGroup>
 
@@ -165,7 +149,7 @@ Add `@mcp-b/global` via unpkg and use `registerTool()` for zero-config setup - n
 
 ```bash
 git clone https://github.com/WebMCP-org/examples.git
-cd examples/vanilla-ts  # or any example
+cd examples/vanilla  # or react
 pnpm install --ignore-workspace
 pnpm dev
 ```

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -30,7 +30,7 @@ WebMCP is built on a **human-in-the-loop** philosophy:
 - **Collaborative workflows** - Humans and AI work together, not separately
 - **Context engineering** - Like good web design guides users, good WebMCP guides AI by exposing the right tools at the right time
 
-<Card title="Why WebMCP?" icon="lightbulb" href="/why-webmcp">
+<Card title="Why WebMCP?" icon="lightbulb" href="/concepts/why-webmcp">
   Understand why WebMCP is a better approach than browser automation, remote APIs, or computer use
 </Card>
 

--- a/packages/extension-tools.mdx
+++ b/packages/extension-tools.mdx
@@ -233,7 +233,7 @@ const displayTools = new SystemDisplayApiTools(server, {
 
 ## Real-World Example: Extension Connector
 
-From the [extension-connector example](https://github.com/WebMCP-org/examples/tree/main/extension-connector):
+Here's an example of connecting to an MCP extension:
 
 ```typescript
 // background.ts
@@ -446,7 +446,6 @@ const options: TabsApiToolsOptions = {
 ## External Resources
 
 - [@modelcontextprotocol/sdk](https://www.npmjs.com/package/@modelcontextprotocol/sdk) - Core MCP SDK
-- [Extension Connector Example](https://github.com/WebMCP-org/examples/tree/main/extension-connector) - Working example
 - [Chrome Extension API Reference](https://developer.chrome.com/docs/extensions/reference/) - Official Chrome docs
 - [MCP Protocol Specification](https://modelcontextprotocol.io) - Protocol details
 - [GitHub Repository](https://github.com/WebMCP-org/npm-packages) - Source code

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -187,17 +187,17 @@ Wrap your existing application logic as tools:
   <Card
     title="Vanilla TypeScript"
     icon="js"
-    href="https://github.com/WebMCP-org/examples/tree/main/vanilla-ts"
+    href="https://github.com/WebMCP-org/examples/tree/main/vanilla"
   >
-    Todo app with dynamic tool registration
+    Shopping cart app with dynamic tool registration
   </Card>
 
   <Card
-    title="Script Tag"
-    icon="code"
-    href="https://github.com/WebMCP-org/examples/tree/main/script-tag"
+    title="React Task Manager"
+    icon="react"
+    href="https://github.com/WebMCP-org/examples/tree/main/react"
   >
-    Zero-config setup with no build tools
+    Task management app demonstrating useWebMCP() hook
   </Card>
 
   <Card


### PR DESCRIPTION
- Fix /why-webmcp → /concepts/why-webmcp in introduction.mdx
- Fix /concepts/security → /security in concepts/architecture.mdx