### PR TITLE
chore: remove redundant NPM Package anchor from global navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -56,11 +56,6 @@
           "href": "https://webmcp.sh"
         },
         {
-          "anchor": "NPM Package",
-          "icon": "npm",
-          "href": "https://www.npmjs.com/package/@mcp-b/transports"
-        },
-        {
           "anchor": "Examples",
           "icon": "code",
           "href": "https://github.com/WebMCP-org/examples"


### PR DESCRIPTION
The anchor only linked to one package (@mcp-b/transports) when there are
multiple NPM packages documented. Users can access packages via the
navbar link or the NPM Packages section in the docs.