### PR TITLE
docs: rework framework integrations to emphasize examples and Chrome DevTools MCP

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -240,7 +240,8 @@
           {
             "group": "Backend Frameworks",
             "pages": [
-              "frameworks/rails"
+              "frameworks/rails",
+              "frameworks/phoenix-liveview"
             ]
           }
         ]

--- a/frameworks/angular.mdx
+++ b/frameworks/angular.mdx
@@ -4,11 +4,20 @@ description: 'Integrate WebMCP tools with Angular using services and lifecycle h
 icon: 'angular'
 ---
 
-<Info>
-**Prerequisites**: Install `@mcp-b/global` per the [Global Package docs](/packages/global). For the full API, see [Tool Registration](/concepts/tool-registration).
-</Info>
+<Card title="Full Example" icon="github" href="https://github.com/WebMCP-org/examples/tree/main/angular">
+  Production-ready Angular example with signals and services
+</Card>
 
-## Basic Component Usage
+## Quick start
+
+```bash
+git clone https://github.com/WebMCP-org/examples.git
+cd examples/angular && pnpm install && pnpm dev
+```
+
+## The pattern
+
+Use `ngOnInit`/`ngOnDestroy` for lifecycle management:
 
 ```typescript "my.component.ts"
 import { Component, OnInit, OnDestroy } from '@angular/core';
@@ -45,7 +54,7 @@ export class MyComponent implements OnInit, OnDestroy {
 }
 ```
 
-## SSR-Safe (Angular Universal)
+## Angular Universal (SSR)
 
 Use `isPlatformBrowser` for SSR safety:
 
@@ -54,10 +63,7 @@ import { Component, OnInit, OnDestroy, PLATFORM_ID, Inject } from '@angular/core
 import { isPlatformBrowser } from '@angular/common';
 import '@mcp-b/global';
 
-@Component({
-  selector: 'app-my',
-  template: `<p>Content</p>`
-})
+@Component({ /* ... */ })
 export class MyComponent implements OnInit, OnDestroy {
   private reg: { unregister: () => void } | null = null;
   private isBrowser: boolean;
@@ -68,13 +74,7 @@ export class MyComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     if (!this.isBrowser || !('modelContext' in navigator)) return;
-
-    this.reg = navigator.modelContext.registerTool({
-      name: 'my_tool',
-      description: 'My tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: async () => ({ content: [{ type: 'text', text: 'Done' }] })
-    });
+    this.reg = navigator.modelContext.registerTool({ /* ... */ });
   }
 
   ngOnDestroy() {
@@ -83,84 +83,15 @@ export class MyComponent implements OnInit, OnDestroy {
 }
 ```
 
-## Creating a Service
-
-For reuse across components:
-
-```typescript "webmcp.service.ts"
-import { Injectable, OnDestroy, PLATFORM_ID, Inject } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
-import '@mcp-b/global';
-
-@Injectable({ providedIn: 'root' })
-export class WebMCPService implements OnDestroy {
-  private registrations = new Map<string, { unregister: () => void }>();
-  readonly isAvailable: boolean;
-
-  constructor(@Inject(PLATFORM_ID) platformId: object) {
-    this.isAvailable = isPlatformBrowser(platformId) && 'modelContext' in navigator;
-  }
-
-  register(tool: Parameters<typeof navigator.modelContext.registerTool>[0]) {
-    if (!this.isAvailable) return null;
-    const reg = navigator.modelContext.registerTool(tool);
-    this.registrations.set(tool.name, reg);
-    return reg;
-  }
-
-  unregister(name: string) {
-    this.registrations.get(name)?.unregister();
-    this.registrations.delete(name);
-  }
-
-  ngOnDestroy() {
-    this.registrations.forEach(r => r.unregister());
-  }
-}
-```
-
-```typescript "my.component.ts"
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
-import { WebMCPService } from './webmcp.service';
-
-@Component({
-  selector: 'app-my',
-  template: `<p>Content</p>`
-})
-export class MyComponent implements OnInit, OnDestroy {
-  private webmcp = inject(WebMCPService);
-
-  ngOnInit() {
-    this.webmcp.register({
-      name: 'my_tool',
-      description: 'My tool',
-      inputSchema: { type: 'object', properties: {} },
-      execute: async () => ({ content: [{ type: 'text', text: 'Done' }] })
-    });
-  }
-
-  ngOnDestroy() {
-    this.webmcp.unregister('my_tool');
-  }
-}
-```
-
-## Common Gotchas
+## Common issues
 
 <AccordionGroup>
   <Accordion title="'navigator is not defined' with Angular Universal">
-    Use platform checks:
-    ```typescript
-    constructor(@Inject(PLATFORM_ID) platformId: object) {
-      if (isPlatformBrowser(platformId)) {
-        // Safe to use navigator
-      }
-    }
-    ```
+    Use `isPlatformBrowser()` platform check before accessing `navigator`.
   </Accordion>
 
   <Accordion title="Zone.js and async handlers">
-    If you need change detection after tool execution, use `NgZone.run()`:
+    If change detection doesn't trigger after tool execution, wrap in `NgZone.run()`:
     ```typescript
     execute: async (args) => {
       return this.ngZone.run(() => {
@@ -171,3 +102,7 @@ export class MyComponent implements OnInit, OnDestroy {
     ```
   </Accordion>
 </AccordionGroup>
+
+## Development
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for AI-driven development - your AI can write, discover, and test tools in real-time.

--- a/frameworks/index.mdx
+++ b/frameworks/index.mdx
@@ -1,12 +1,85 @@
 ---
 title: 'Framework Integrations'
-description: 'Integrate WebMCP with Vue, Nuxt, Svelte, Rails, Angular, and other web frameworks.'
+description: 'Integrate WebMCP with any JavaScript or backend framework using production-ready examples.'
 icon: 'grid-2'
 ---
 
-WebMCP works with any JavaScript framework. While we provide first-class React support via [`@mcp-b/react-webmcp`](/packages/react-webmcp), you can integrate WebMCP into any framework using [`@mcp-b/global`](/packages/global).
+WebMCP works with any framework. Use Chrome DevTools MCP for the best development experience, then explore our production-ready examples.
 
-## The Pattern
+## Development workflow
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for a powerful AI-driven development loop:
+
+```mermaid
+flowchart LR
+    A[AI writes tool] --> B[Dev server hot-reloads]
+    B --> C[AI navigates to page]
+    C --> D[list_webmcp_tools]
+    D --> E[call_webmcp_tool]
+    E --> F{Works?}
+    F -->|No| A
+    F -->|Yes| G[Done]
+```
+
+<Steps>
+  <Step title="Install Chrome DevTools MCP">
+    ```bash
+    claude mcp add chrome-devtools npx @mcp-b/chrome-devtools-mcp@latest
+    ```
+  </Step>
+
+  <Step title="Start your dev server">
+    ```bash
+    pnpm dev
+    ```
+  </Step>
+
+  <Step title="Ask your AI to build and test tools">
+    The AI can write tool code, navigate to your page, discover tools via `list_webmcp_tools`, and test them with `call_webmcp_tool` - all in a tight feedback loop.
+  </Step>
+</Steps>
+
+<Info>
+This is **TDD for AI** - agents build and verify their own tools in real-time.
+</Info>
+
+## Production examples
+
+Clone any example to get started immediately:
+
+```bash
+git clone https://github.com/WebMCP-org/examples.git
+cd examples/<framework>
+pnpm install && pnpm dev
+```
+
+<CardGroup cols={2}>
+  <Card title="Vanilla JavaScript" icon="js" href="https://github.com/WebMCP-org/examples/tree/main/vanilla">
+    Shopping cart with core WebMCP functionality
+  </Card>
+
+  <Card title="React" icon="react" href="https://github.com/WebMCP-org/examples/tree/main/react">
+    Task manager with `useWebMCP()` hook
+  </Card>
+
+  <Card title="Svelte" icon="code" href="https://github.com/WebMCP-org/examples/tree/main/svelte">
+    Svelte 5 with runes and actions
+  </Card>
+
+  <Card title="Angular" icon="angular" href="https://github.com/WebMCP-org/examples/tree/main/angular">
+    Note-taking app with Angular signals
+  </Card>
+
+  <Card title="Rails" icon="gem" href="https://github.com/WebMCP-org/examples/tree/main/rails">
+    Bookmarks manager with Stimulus controllers
+  </Card>
+
+  <Card title="Phoenix LiveView" icon="fire" href="https://github.com/WebMCP-org/examples/tree/main/phoenix-liveview">
+    Real-time sync with server-side state
+  </Card>
+</CardGroup>
+
+## The pattern
 
 All frameworks follow the same approach:
 
@@ -14,54 +87,44 @@ All frameworks follow the same approach:
 2. Call `registerTool()` in your mount lifecycle
 3. Call `unregister()` in your unmount lifecycle
 
-```javascript
-import '@mcp-b/global';
+| Framework | Mount | Unmount | Example |
+|-----------|-------|---------|---------|
+| [React](/packages/react-webmcp) | `useWebMCP()` hook | automatic | [View](https://github.com/WebMCP-org/examples/tree/main/react) |
+| [Vue 3](/frameworks/vue) | `onMounted` | `onUnmounted` | [Community](https://github.com/bestian/vue-MCP-B-demo) |
+| [Nuxt 3](/frameworks/nuxt) | `onMounted` + `import.meta.client` | `onUnmounted` | [Community](https://github.com/mikechao/nuxt3-mcp-b-demo) |
+| [Svelte](/frameworks/svelte) | `onMount` | `onDestroy` | [View](https://github.com/WebMCP-org/examples/tree/main/svelte) |
+| [Angular](/frameworks/angular) | `ngOnInit` | `ngOnDestroy` | [View](https://github.com/WebMCP-org/examples/tree/main/angular) |
+| [Rails/Stimulus](/frameworks/rails) | `connect` | `disconnect` | [View](https://github.com/WebMCP-org/examples/tree/main/rails) |
+| [Phoenix LiveView](/frameworks/phoenix-liveview) | `mounted` | `destroyed` | [View](https://github.com/WebMCP-org/examples/tree/main/phoenix-liveview) |
 
-// In your mount hook:
-const reg = navigator.modelContext.registerTool({
-  name: 'my_tool',
-  description: 'Does something useful',
-  inputSchema: { type: 'object', properties: {} },
-  execute: async () => ({ content: [{ type: 'text', text: 'Done' }] })
-});
+## React users
 
-// In your unmount hook:
-reg.unregister();
-```
+Use [`@mcp-b/react-webmcp`](/packages/react-webmcp) instead of `@mcp-b/global` - it handles lifecycle automatically and provides Zod validation.
 
-## Framework Guides
-
-| Framework | Mount | Unmount |
-|-----------|-------|---------|
-| [Vue 3](/frameworks/vue) | `onMounted` | `onUnmounted` |
-| [Nuxt 3](/frameworks/nuxt) | `onMounted` + `import.meta.client` | `onUnmounted` |
-| [Svelte](/frameworks/svelte) | `onMount` | `onDestroy` |
-| [SvelteKit](/frameworks/svelte) | `onMount` + `browser` check | `onDestroy` |
-| [Angular](/frameworks/angular) | `ngOnInit` | `ngOnDestroy` |
-| [Rails/Stimulus](/frameworks/rails) | `connect` | `disconnect` |
+## Framework-specific guides
 
 <CardGroup cols={2}>
   <Card title="Vue.js" icon="vuejs" href="/frameworks/vue">
-    Composition API patterns
+    Composition API patterns and SSR considerations
   </Card>
 
   <Card title="Nuxt" icon="n" href="/frameworks/nuxt">
-    SSR-safe patterns
+    SSR-safe patterns with `import.meta.client`
   </Card>
 
   <Card title="Svelte" icon="code" href="/frameworks/svelte">
-    Actions and runes
+    Actions, runes, and SvelteKit patterns
   </Card>
 
   <Card title="Angular" icon="angular" href="/frameworks/angular">
-    Services and DI
+    Services, DI, and Angular Universal
   </Card>
 
   <Card title="Rails" icon="gem" href="/frameworks/rails">
-    Stimulus controllers
+    Stimulus controllers and Turbo integration
+  </Card>
+
+  <Card title="Phoenix LiveView" icon="fire" href="/frameworks/phoenix-liveview">
+    Server-side state with real-time sync
   </Card>
 </CardGroup>
-
-## React Users
-
-Use [`@mcp-b/react-webmcp`](/packages/react-webmcp) instead - it handles lifecycle automatically.

--- a/frameworks/nuxt.mdx
+++ b/frameworks/nuxt.mdx
@@ -4,9 +4,9 @@ description: 'Integrate WebMCP tools with Nuxt 3, handling SSR safely.'
 icon: 'n'
 ---
 
-<Info>
-**Prerequisites**: Install `@mcp-b/global` per the [Global Package docs](/packages/global). For base Vue patterns, see [Vue Integration](/frameworks/vue).
-</Info>
+<Card title="Community Example" icon="github" href="https://github.com/mikechao/nuxt3-mcp-b-demo">
+  Full-stack Nuxt 3 with SSR support by Mike Chao
+</Card>
 
 Nuxt's SSR requires ensuring WebMCP code only runs on the client.
 
@@ -104,3 +104,7 @@ For client-only components:
     Register tools in `app.vue` or a layout so they persist across routes.
   </Accordion>
 </AccordionGroup>
+
+## Development
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for AI-driven development - your AI can write, discover, and test tools in real-time.

--- a/frameworks/phoenix-liveview.mdx
+++ b/frameworks/phoenix-liveview.mdx
@@ -1,0 +1,132 @@
+---
+title: 'Phoenix LiveView Integration'
+description: 'Integrate WebMCP tools with Phoenix LiveView using JavaScript hooks.'
+icon: 'fire'
+---
+
+<Card title="Full Example" icon="github" href="https://github.com/WebMCP-org/examples/tree/main/phoenix-liveview">
+  Production-ready Phoenix LiveView example with real-time sync
+</Card>
+
+## Quick start
+
+```bash
+git clone https://github.com/WebMCP-org/examples.git
+cd examples/phoenix-liveview && mix deps.get && mix phx.server
+```
+
+## Why Phoenix LiveView?
+
+Phoenix LiveView's server-side state management creates a powerful pattern for WebMCP:
+
+- **Server-authoritative state** - Tools call into LiveView, which manages all state
+- **Real-time sync** - Changes push to all connected clients instantly
+- **No client state bugs** - AI tool calls and manual interactions stay in sync
+
+## The pattern
+
+Use LiveView JavaScript hooks with `mounted`/`destroyed` lifecycle:
+
+```javascript "assets/js/hooks/webmcp.js"
+import "@mcp-b/global"
+
+export const WebMCPHook = {
+  mounted() {
+    if (!('modelContext' in navigator)) return
+
+    this.registration = navigator.modelContext.registerTool({
+      name: 'increment',
+      description: 'Increment the counter',
+      inputSchema: {
+        type: 'object',
+        properties: { amount: { type: 'number' } }
+      },
+      execute: async ({ amount = 1 }) => {
+        // Push event to LiveView server
+        this.pushEvent('increment', { amount })
+        return { content: [{ type: 'text', text: 'Incremented' }] }
+      }
+    })
+  },
+
+  destroyed() {
+    this.registration?.unregister()
+  }
+}
+```
+
+```javascript "assets/js/app.js"
+import { WebMCPHook } from "./hooks/webmcp"
+
+let liveSocket = new LiveSocket("/live", Socket, {
+  hooks: { WebMCPHook }
+})
+```
+
+```elixir "lib/app_web/live/counter_live.ex"
+defmodule AppWeb.CounterLive do
+  use AppWeb, :live_view
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, count: 0)}
+  end
+
+  def handle_event("increment", %{"amount" => amount}, socket) do
+    {:noreply, update(socket, :count, &(&1 + amount))}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div phx-hook="WebMCPHook" id="counter">
+      <p>Count: <%= @count %></p>
+    </div>
+    """
+  end
+end
+```
+
+## Installation
+
+Add `@mcp-b/global` to your JavaScript dependencies:
+
+```bash
+cd assets && npm install @mcp-b/global
+```
+
+## Bidirectional communication
+
+The power of LiveView + WebMCP is bidirectional:
+
+1. **AI → Server**: Tool calls push events to LiveView via `this.pushEvent()`
+2. **Server → Client**: LiveView pushes updates to all connected clients
+3. **Client → AI**: Updated DOM state is visible to AI on next tool call
+
+```javascript
+execute: async ({ item_name }) => {
+  // Push to server, get response via callback
+  this.pushEvent('add_item', { name: item_name }, (reply) => {
+    console.log('Server responded:', reply)
+  })
+  return { content: [{ type: 'text', text: `Added ${item_name}` }] }
+}
+```
+
+## Common issues
+
+<AccordionGroup>
+  <Accordion title="Hook not mounting">
+    Ensure the hook is registered in `app.js` and the element has both `phx-hook` and a unique `id` attribute.
+  </Accordion>
+
+  <Accordion title="Tool calls not reaching server">
+    Check that `this.pushEvent()` is being called. LiveView hooks must use `this.pushEvent()`, not regular fetch calls.
+  </Accordion>
+
+  <Accordion title="State out of sync">
+    LiveView handles this automatically - tool calls go to server, server broadcasts to all clients.
+  </Accordion>
+</AccordionGroup>
+
+## Development
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for AI-driven development - your AI can write, discover, and test tools in real-time.

--- a/frameworks/rails.mdx
+++ b/frameworks/rails.mdx
@@ -4,9 +4,16 @@ description: 'Integrate WebMCP tools with Ruby on Rails using Stimulus controlle
 icon: 'gem'
 ---
 
-<Info>
-**Prerequisites**: For the full API, see [Global Package](/packages/global) and [Tool Registration](/concepts/tool-registration).
-</Info>
+<Card title="Full Example" icon="github" href="https://github.com/WebMCP-org/examples/tree/main/rails">
+  Production-ready Rails example with Stimulus controllers
+</Card>
+
+## Quick start
+
+```bash
+git clone https://github.com/WebMCP-org/examples.git
+cd examples/rails && bundle install && bin/rails server
+```
 
 ## Installation
 
@@ -20,7 +27,9 @@ bin/importmap pin @mcp-b/global
 npm install @mcp-b/global
 ```
 
-## Basic Stimulus Controller
+## The pattern
+
+Use Stimulus `connect`/`disconnect` for lifecycle management:
 
 ```javascript "app/javascript/controllers/webmcp_controller.js"
 import { Controller } from "@hotwired/stimulus"
@@ -28,7 +37,6 @@ import "@mcp-b/global"
 
 export default class extends Controller {
   static values = { name: String, description: String }
-
   #registration = null
 
   connect() {
@@ -58,53 +66,9 @@ export default class extends Controller {
 </div>
 ```
 
-## With Backend API
+## Turbo persistence
 
-```javascript "app/javascript/controllers/cart_controller.js"
-import { Controller } from "@hotwired/stimulus"
-import "@mcp-b/global"
-
-export default class extends Controller {
-  #registration = null
-
-  connect() {
-    if (!('modelContext' in navigator)) return
-
-    this.#registration = navigator.modelContext.registerTool({
-      name: 'add_to_cart',
-      description: 'Add a product to the cart',
-      inputSchema: {
-        type: 'object',
-        properties: {
-          productId: { type: 'string' },
-          quantity: { type: 'number' }
-        },
-        required: ['productId']
-      },
-      execute: async ({ productId, quantity = 1 }) => {
-        const response = await fetch('/cart/items', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
-          },
-          body: JSON.stringify({ product_id: productId, quantity })
-        })
-        const result = await response.json()
-        return { content: [{ type: 'text', text: JSON.stringify(result) }] }
-      }
-    })
-  }
-
-  disconnect() {
-    this.#registration?.unregister()
-  }
-}
-```
-
-## Global Tools
-
-Attach to `<body>` for persistence across Turbo navigations:
+Attach controllers to `<body>` for persistence across Turbo navigations:
 
 ```erb
 <%# app/views/layouts/application.html.erb %>
@@ -113,42 +77,11 @@ Attach to `<body>` for persistence across Turbo navigations:
 </body>
 ```
 
-```javascript "app/javascript/controllers/global_tools_controller.js"
-import { Controller } from "@hotwired/stimulus"
-import "@mcp-b/global"
-
-export default class extends Controller {
-  #registration = null
-
-  connect() {
-    if (!('modelContext' in navigator)) return
-
-    this.#registration = navigator.modelContext.registerTool({
-      name: 'navigate',
-      description: 'Navigate to a page',
-      inputSchema: {
-        type: 'object',
-        properties: { path: { type: 'string' } },
-        required: ['path']
-      },
-      execute: async ({ path }) => {
-        Turbo.visit(path)
-        return { content: [{ type: 'text', text: `Navigating to ${path}` }] }
-      }
-    })
-  }
-
-  disconnect() {
-    this.#registration?.unregister()
-  }
-}
-```
-
-## Common Gotchas
+## Common issues
 
 <AccordionGroup>
   <Accordion title="CSRF token issues">
-    Include the CSRF token in requests:
+    Include the CSRF token in fetch requests:
     ```javascript
     headers: {
       'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
@@ -157,18 +90,14 @@ export default class extends Controller {
   </Accordion>
 
   <Accordion title="Tools not registering after Turbo navigation">
-    Place controllers on `<body>` so they persist, or use `turbo:load` event:
-    ```javascript
-    document.addEventListener('turbo:load', () => {
-      // Re-register if needed
-    })
-    ```
+    Place controllers on `<body>` so they persist, or handle `turbo:load` event.
   </Accordion>
 
   <Accordion title="importmap not finding @mcp-b/global">
-    Pin the package:
-    ```bash
-    bin/importmap pin @mcp-b/global
-    ```
+    Pin the package: `bin/importmap pin @mcp-b/global`
   </Accordion>
 </AccordionGroup>
+
+## Development
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for AI-driven development - your AI can write, discover, and test tools in real-time.

--- a/frameworks/svelte.mdx
+++ b/frameworks/svelte.mdx
@@ -4,11 +4,20 @@ description: 'Integrate WebMCP tools with Svelte and SvelteKit.'
 icon: 'code'
 ---
 
-<Info>
-**Prerequisites**: Install `@mcp-b/global` per the [Global Package docs](/packages/global). For the full API, see [Tool Registration](/concepts/tool-registration).
-</Info>
+<Card title="Full Example" icon="github" href="https://github.com/WebMCP-org/examples/tree/main/svelte">
+  Production-ready Svelte example with runes and actions
+</Card>
 
-## Basic Usage (Svelte 5)
+## Quick start
+
+```bash
+git clone https://github.com/WebMCP-org/examples.git
+cd examples/svelte && pnpm install && pnpm dev
+```
+
+## The pattern
+
+Use `onMount`/`onDestroy` for lifecycle management:
 
 ```svelte
 <script lang="ts">
@@ -24,9 +33,7 @@ icon: 'code'
       description: 'Increment the counter',
       inputSchema: {
         type: 'object',
-        properties: {
-          amount: { type: 'number' }
-        }
+        properties: { amount: { type: 'number' } }
       },
       async execute({ amount = 1 }) {
         count += amount as number;
@@ -41,9 +48,9 @@ icon: 'code'
 <p>Count: {count}</p>
 ```
 
-## SvelteKit (SSR-Safe)
+## SvelteKit SSR
 
-Use the `browser` check for SvelteKit:
+Add the `browser` check to avoid SSR errors:
 
 ```svelte "+page.svelte"
 <script lang="ts">
@@ -51,36 +58,20 @@ Use the `browser` check for SvelteKit:
   import { onMount, onDestroy } from 'svelte';
   import '@mcp-b/global';
 
-  export let data;
   let reg: { unregister: () => void } | null = null;
 
   onMount(() => {
     if (!browser) return;
-
-    reg = navigator.modelContext.registerTool({
-      name: 'search',
-      description: 'Search loaded data',
-      inputSchema: {
-        type: 'object',
-        properties: { query: { type: 'string' } },
-        required: ['query']
-      },
-      async execute({ query }) {
-        const results = data.items.filter(i =>
-          i.name.toLowerCase().includes((query as string).toLowerCase())
-        );
-        return { content: [{ type: 'text', text: JSON.stringify(results) }] };
-      }
-    });
+    reg = navigator.modelContext.registerTool({ /* ... */ });
   });
 
   onDestroy(() => reg?.unregister());
 </script>
 ```
 
-## Using Actions
+## Using actions
 
-Svelte actions can encapsulate tool registration:
+Svelte actions encapsulate tool registration cleanly:
 
 ```typescript "lib/actions/webmcp.ts"
 import '@mcp-b/global';
@@ -92,68 +83,23 @@ export function webmcp(node: HTMLElement, tool: Parameters<typeof navigator.mode
 ```
 
 ```svelte
-<script lang="ts">
-  import { webmcp } from '$lib/actions/webmcp';
-</script>
-
-<div use:webmcp={{
-  name: 'my_tool',
-  description: 'My tool',
-  inputSchema: { type: 'object', properties: {} },
-  async execute() {
-    return { content: [{ type: 'text', text: 'Done' }] };
-  }
-}}>
+<div use:webmcp={{ name: 'my_tool', description: 'My tool', ... }}>
   Content
 </div>
 ```
 
-## Layout-Level Tools
-
-Register in `+layout.svelte` for persistence across routes:
-
-```svelte "+layout.svelte"
-<script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
-  import { goto } from '$app/navigation';
-  import '@mcp-b/global';
-
-  let reg: { unregister: () => void } | null = null;
-
-  onMount(() => {
-    reg = navigator.modelContext.registerTool({
-      name: 'navigate',
-      description: 'Navigate to a page',
-      inputSchema: {
-        type: 'object',
-        properties: { path: { type: 'string' } },
-        required: ['path']
-      },
-      async execute({ path }) {
-        await goto(path as string);
-        return { content: [{ type: 'text', text: `Navigated to ${path}` }] };
-      }
-    });
-  });
-
-  onDestroy(() => reg?.unregister());
-</script>
-
-<slot />
-```
-
-## Common Gotchas
+## Common issues
 
 <AccordionGroup>
   <Accordion title="'navigator is not defined' during SSR">
-    Use the `browser` check:
-    ```typescript
-    import { browser } from '$app/environment';
-    if (browser) { /* safe to use navigator */ }
-    ```
+    Use the `browser` check from `$app/environment` in SvelteKit.
   </Accordion>
 
   <Accordion title="Tools disappear after navigation">
-    Move registration to `+layout.svelte` for persistence.
+    Move registration to `+layout.svelte` for persistence across routes.
   </Accordion>
 </AccordionGroup>
+
+## Development
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for AI-driven development - your AI can write, discover, and test tools in real-time.

--- a/frameworks/vue.mdx
+++ b/frameworks/vue.mdx
@@ -4,9 +4,9 @@ description: 'Integrate WebMCP tools with Vue 3 using the Composition API.'
 icon: 'vuejs'
 ---
 
-<Info>
-**Prerequisites**: Install `@mcp-b/global` per the [Global Package docs](/packages/global). For the full API, see [Tool Registration](/concepts/tool-registration).
-</Info>
+<Card title="Community Example" icon="github" href="https://github.com/bestian/vue-MCP-B-demo">
+  Vue 3 Composition API integration by Besian
+</Card>
 
 ## Basic Usage
 
@@ -117,3 +117,7 @@ useWebMCPTool({
     ```
   </Accordion>
 </AccordionGroup>
+
+## Development
+
+Use [Chrome DevTools MCP](/packages/chrome-devtools-mcp) for AI-driven development - your AI can write, discover, and test tools in real-time.


### PR DESCRIPTION
- Lead with Chrome DevTools MCP as the primary development workflow
- Point to production-ready examples in WebMCP-org/examples repo
- Simplify framework pages to core patterns + links to full examples
- Add Phoenix LiveView integration page (new framework example)
- Add development workflow callouts to all framework pages