### PR TITLE
docs: fix useWebMCPPrompt API example to match actual types

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -20,14 +20,20 @@ Full Web Model Context API support now extends beyond tools to include **prompts
 
 ```tsx
 import { useWebMCPPrompt, useWebMCPResource } from '@mcp-b/react-webmcp';
+import { z } from 'zod';
 
 // Register a prompt
 useWebMCPPrompt({
   name: 'summarize',
   description: 'Summarize the current page content',
-  arguments: [{ name: 'format', description: 'Output format' }],
-  handler: async (args) => ({
-    messages: [{ role: 'user', content: `Summarize in ${args.format} format` }]
+  argsSchema: {
+    format: z.string().describe('Output format'),
+  },
+  get: async (args) => ({
+    messages: [{
+      role: 'user',
+      content: { type: 'text', text: `Summarize in ${args.format} format` }
+    }]
   })
 });
 


### PR DESCRIPTION
The changelog example incorrectly showed:
- `arguments` instead of `argsSchema` (Zod schema)
- `handler` instead of `get`
- `content: string` instead of `content: { type, text }`

This caused confusion when developers followed the docs and got TypeScript errors like "arguments does not exist in type".