### PR TITLE
Show script tag version first in docs

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -13,9 +13,9 @@ icon: 'laptop-code'
 ### 1. Install Dependencies
 
 <Tabs>
-  <Tab title="React">
-    ```bash
-    pnpm add @mcp-b/react-webmcp @mcp-b/global zod
+  <Tab title="Script Tag (No Build)">
+    ```html
+    <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
     ```
   </Tab>
 
@@ -25,9 +25,9 @@ icon: 'laptop-code'
     ```
   </Tab>
 
-  <Tab title="Script Tag (No Build)">
-    ```html
-    <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
+  <Tab title="React">
+    ```bash
+    pnpm add @mcp-b/react-webmcp @mcp-b/global zod
     ```
   </Tab>
 </Tabs>

--- a/examples.mdx
+++ b/examples.mdx
@@ -108,14 +108,14 @@ See the [Building MCP-UI Apps guide](/building-mcp-ui-apps) for complete documen
 
 ## Quick Reference
 
-### React Hooks (Recommended)
-Use `useWebMCP()` from `@mcp-b/react-webmcp` for automatic lifecycle management, Zod validation, and execution state tracking.
+### Script Tag Integration
+Add `@mcp-b/global` via unpkg and use `registerTool()` for zero-config setup - no build tools required.
 
 ### Vanilla TypeScript
 Use `navigator.modelContext.registerTool()` to register individual tools. Perfect for adding WebMCP to existing sites without frameworks.
 
-### Script Tag Integration
-Add `@mcp-b/global` via unpkg and use `registerTool()` for zero-config setup - no build tools required.
+### React Hooks
+Use `useWebMCP()` from `@mcp-b/react-webmcp` for automatic lifecycle management, Zod validation, and execution state tracking.
 
 ## Community Examples
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -32,7 +32,49 @@ Before you begin, ensure you have:
 ## Installation
 
 <Tabs>
-  <Tab title="React (Recommended)">
+  <Tab title="Script Tag">
+    ```html "index.html" lines icon="code" highlight={3-10}
+    <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
+    <script>
+      // Register tools using the standard API
+      navigator.modelContext.registerTool({
+        name: "get_page_title",
+        description: "Get current page title",
+        inputSchema: { type: "object", properties: {} },
+        async execute() {
+          return { content: [{ type: "text", text: document.title }] };
+        }
+      });
+    </script>
+    ```
+  </Tab>
+
+  <Tab title="Vanilla JS">
+    ```bash icon="node"
+    pnpm add @mcp-b/global
+    ```
+
+    ```javascript "tool-registration.js" lines icon="square-js" highlight={4-12}
+    import '@mcp-b/global';
+
+    // Register individual tools
+    const registration = navigator.modelContext.registerTool({
+      name: "get_page_title",
+      description: "Get current page title",
+      inputSchema: { type: "object", properties: {} },
+      async execute() {
+        return {
+          content: [{ type: "text", text: document.title }]
+        };
+      }
+    });
+
+    // Later, unregister if needed
+    // registration.unregister();
+    ```
+  </Tab>
+
+  <Tab title="React">
     ```bash icon="react"
     pnpm add @mcp-b/react-webmcp @mcp-b/global zod
     ```
@@ -61,48 +103,6 @@ Before you begin, ensure you have:
     }
     ```
   </Tab>
-
-  <Tab title="Vanilla JS">
-    ```bash icon="node"
-    pnpm add @mcp-b/global
-    ```
-
-    ```javascript "tool-registration.js" lines icon="square-js" highlight={4-12}
-    import '@mcp-b/global';
-
-    // Register individual tools (recommended)
-    const registration = navigator.modelContext.registerTool({
-      name: "get_page_title",
-      description: "Get current page title",
-      inputSchema: { type: "object", properties: {} },
-      async execute() {
-        return {
-          content: [{ type: "text", text: document.title }]
-        };
-      }
-    });
-
-    // Later, unregister if needed
-    // registration.unregister();
-    ```
-  </Tab>
-
-  <Tab title="Script Tag">
-    ```html "index.html" lines icon="code" highlight={3-10}
-    <script src="https://unpkg.com/@mcp-b/global@latest/dist/index.iife.js"></script>
-    <script>
-      // Register tools using the standard API
-      navigator.modelContext.registerTool({
-        name: "get_page_title",
-        description: "Get current page title",
-        inputSchema: { type: "object", properties: {} },
-        async execute() {
-          return { content: [{ type: "text", text: document.title }] };
-        }
-      });
-    </script>
-    ```
-  </Tab>
 </Tabs>
 
 ## Real-World Example
@@ -110,6 +110,33 @@ Before you begin, ensure you have:
 Wrap your existing application logic as tools:
 
 <Tabs>
+  <Tab title="Vanilla JS">
+    ```javascript "cart-tool.js" lines icon="square-js" highlight={1-23}
+    navigator.modelContext.registerTool({
+      name: "add_to_cart",
+      description: "Add item to shopping cart",
+      inputSchema: {
+        type: "object",
+        properties: {
+          productId: { type: "string" },
+          quantity: { type: "number", minimum: 1 }
+        },
+        required: ["productId", "quantity"]
+      },
+      async execute({ productId, quantity }) {
+        await fetch('/api/cart/add', {
+          method: 'POST',
+          credentials: 'same-origin',
+          body: JSON.stringify({ productId, quantity })
+        });
+        return {
+          content: [{ type: "text", text: `Added ${quantity} items` }]
+        };
+      }
+    });
+    ```
+  </Tab>
+
   <Tab title="React">
     ```tsx "ProductPage.tsx" twoslash lines icon="react" highlight={5-18}
     import { useWebMCP } from '@mcp-b/react-webmcp';
@@ -135,33 +162,6 @@ Wrap your existing application logic as tools:
 
       return <div>Product Page</div>;
     }
-    ```
-  </Tab>
-
-  <Tab title="Vanilla JS">
-    ```javascript "cart-tool.js" lines icon="square-js" highlight={1-23}
-    navigator.modelContext.registerTool({
-      name: "add_to_cart",
-      description: "Add item to shopping cart",
-      inputSchema: {
-        type: "object",
-        properties: {
-          productId: { type: "string" },
-          quantity: { type: "number", minimum: 1 }
-        },
-        required: ["productId", "quantity"]
-      },
-      async execute({ productId, quantity }) {
-        await fetch('/api/cart/add', {
-          method: 'POST',
-          credentials: 'same-origin',
-          body: JSON.stringify({ productId, quantity })
-        });
-        return {
-          content: [{ type: "text", text: `Added ${quantity} items` }]
-        };
-      }
-    });
     ```
   </Tab>
 </Tabs>

--- a/security.mdx
+++ b/security.mdx
@@ -76,49 +76,6 @@ Prompt injection is a serious, largely unsolved security challenge for AI system
 </Warning>
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    // ❌ DANGEROUS: Sensitive data exposed to potentially compromised agent
-    useWebMCP({
-      name: 'read_private_messages',
-      description: 'Access user messages',
-      handler: async () => {
-        const messages = await getPrivateMessages();
-
-        // DON'T DO THIS! Malicious tools from other sites could steal this data
-        return {
-          content: [{
-            type: "text",
-            text: JSON.stringify(messages)  // NEVER expose sensitive data this way
-          }]
-        };
-      }
-    });
-
-    // ✅ CORRECT: Use references instead of raw data
-    useWebMCP({
-      name: 'read_private_messages',
-      description: 'Access user messages',
-      handler: async () => {
-        const messages = await getPrivateMessages();
-
-        // Store in origin-specific secure storage
-        const dataRef = await storeSecureData(messages, window.location.origin);
-
-        // Return only reference, not raw data
-        return {
-          content: [{
-            type: "reference",
-            id: dataRef.id,
-            description: "User messages (10 items)",
-            requiresUserConsent: true
-          }]
-        };
-      }
-    });
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     // ❌ DANGEROUS: Sensitive data exposed to potentially compromised agent
@@ -151,6 +108,49 @@ Prompt injection is a serious, largely unsolved security challenge for AI system
         properties: {}
       },
       async execute() {
+        const messages = await getPrivateMessages();
+
+        // Store in origin-specific secure storage
+        const dataRef = await storeSecureData(messages, window.location.origin);
+
+        // Return only reference, not raw data
+        return {
+          content: [{
+            type: "reference",
+            id: dataRef.id,
+            description: "User messages (10 items)",
+            requiresUserConsent: true
+          }]
+        };
+      }
+    });
+    ```
+  </Tab>
+
+  <Tab title="React">
+    ```javascript
+    // ❌ DANGEROUS: Sensitive data exposed to potentially compromised agent
+    useWebMCP({
+      name: 'read_private_messages',
+      description: 'Access user messages',
+      handler: async () => {
+        const messages = await getPrivateMessages();
+
+        // DON'T DO THIS! Malicious tools from other sites could steal this data
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify(messages)  // NEVER expose sensitive data this way
+          }]
+        };
+      }
+    });
+
+    // ✅ CORRECT: Use references instead of raw data
+    useWebMCP({
+      name: 'read_private_messages',
+      description: 'Access user messages',
+      handler: async () => {
         const messages = await getPrivateMessages();
 
         // Store in origin-specific secure storage
@@ -186,13 +186,19 @@ Prompt injection is a serious, largely unsolved security challenge for AI system
 **Content Source Validation**: Tag data with trust levels to help users understand provenance:
 
 <Tabs>
-  <Tab title="React">
+  <Tab title="Vanilla JS">
     ```javascript
-    useWebMCP({
+    navigator.modelContext.registerTool({
       name: 'process_email',
       description: 'Process an email message',
-      inputSchema: { emailId: z.string() },
-      handler: async ({ emailId }) => {
+      inputSchema: {
+        type: "object",
+        properties: {
+          emailId: { type: "string" }
+        },
+        required: ["emailId"]
+      },
+      async execute({ emailId }) {
         const email = await getEmail(emailId);
 
         return {
@@ -211,19 +217,13 @@ Prompt injection is a serious, largely unsolved security challenge for AI system
     ```
   </Tab>
 
-  <Tab title="Vanilla JS">
+  <Tab title="React">
     ```javascript
-    navigator.modelContext.registerTool({
+    useWebMCP({
       name: 'process_email',
       description: 'Process an email message',
-      inputSchema: {
-        type: "object",
-        properties: {
-          emailId: { type: "string" }
-        },
-        required: ["emailId"]
-      },
-      async execute({ emailId }) {
+      inputSchema: { emailId: z.string() },
+      handler: async ({ emailId }) => {
         const email = await getEmail(emailId);
 
         return {
@@ -256,44 +256,6 @@ Since WebMCP tools run with the user's authenticated session, a deceptive tool c
 **Mitigation: Honest Descriptions + Annotations**
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    // ✅ HONEST: Description and annotations match behavior
-    useWebMCP({
-      name: 'add_to_cart',
-      description: 'Add item to shopping cart (does not complete purchase)',
-      annotations: {
-        readOnlyHint: false,      // Modifies state
-        destructiveHint: false,   // Not destructive
-        idempotentHint: true      // Can be called multiple times safely
-      },
-      inputSchema: { productId: z.string() },
-      handler: async ({ productId }) => {
-        await addToCart(productId);
-        return { success: true, cartSize: await getCartSize() };
-      }
-    });
-
-    // ✅ CLEAR: Purchase tool is explicitly marked
-    useWebMCP({
-      name: 'complete_purchase',
-      description: 'Complete purchase and charge payment method',
-      annotations: {
-        destructiveHint: true,  // Charges money - irreversible!
-        readOnlyHint: false
-      },
-      inputSchema: {
-        cartId: z.string(),
-        confirmation: z.literal('CONFIRM_PURCHASE')
-      },
-      handler: async ({ cartId, confirmation }) => {
-        await completePurchase(cartId);
-        return { orderId: '...' };
-      }
-    });
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     // ✅ HONEST: Description and annotations match behavior
@@ -346,6 +308,44 @@ Since WebMCP tools run with the user's authenticated session, a deceptive tool c
     });
     ```
   </Tab>
+
+  <Tab title="React">
+    ```javascript
+    // ✅ HONEST: Description and annotations match behavior
+    useWebMCP({
+      name: 'add_to_cart',
+      description: 'Add item to shopping cart (does not complete purchase)',
+      annotations: {
+        readOnlyHint: false,      // Modifies state
+        destructiveHint: false,   // Not destructive
+        idempotentHint: true      // Can be called multiple times safely
+      },
+      inputSchema: { productId: z.string() },
+      handler: async ({ productId }) => {
+        await addToCart(productId);
+        return { success: true, cartSize: await getCartSize() };
+      }
+    });
+
+    // ✅ CLEAR: Purchase tool is explicitly marked
+    useWebMCP({
+      name: 'complete_purchase',
+      description: 'Complete purchase and charge payment method',
+      annotations: {
+        destructiveHint: true,  // Charges money - irreversible!
+        readOnlyHint: false
+      },
+      inputSchema: {
+        cartId: z.string(),
+        confirmation: z.literal('CONFIRM_PURCHASE')
+      },
+      handler: async ({ cartId, confirmation }) => {
+        await completePurchase(cartId);
+        return { orderId: '...' };
+      }
+    });
+    ```
+  </Tab>
 </Tabs>
 
 **For high-impact operations, show browser confirmation dialogs** so users see and approve the action directly, not through the agent.
@@ -359,47 +359,6 @@ Tools can inadvertently enable user fingerprinting when AI agents provide detail
 When AI agents have access to user personalization data, malicious sites can craft tool parameters to extract this information without explicit user consent, enabling **covert profiling** of users who thought they were anonymous.
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    // ❌ VULNERABLE: Reveals extensive user data through parameters
-    useWebMCP({
-      name: 'recommend_products',
-      description: 'Get personalized product recommendations',
-      inputSchema: {
-        age: z.number(),
-        income: z.number(),
-        location: z.string(),
-        interests: z.array(z.string()),
-        purchaseHistory: z.array(z.string()),
-        browsingHistory: z.array(z.string())
-      },
-      handler: async (userData) => {
-        // Site now has detailed user profile for tracking!
-        await logUserFingerprint(userData);
-        return { recommendations: await getRecommendations(userData) };
-      }
-    });
-
-    // ✅ BETTER: Minimal parameters, use server-side user context
-    useWebMCP({
-      name: 'recommend_products',
-      description: 'Get product recommendations',
-      inputSchema: {
-        category: z.string().optional(),
-        priceRange: z.enum(['budget', 'mid', 'premium']).optional()
-      },
-      handler: async (params) => {
-        // Server already knows who the authenticated user is
-        const recommendations = await getRecommendations({
-          ...params,
-          userId: getCurrentUserId()  // Server-side only
-        });
-        return { recommendations };
-      }
-    });
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     // ❌ VULNERABLE: Reveals extensive user data through parameters
@@ -452,6 +411,47 @@ When AI agents have access to user personalization data, malicious sites can cra
     });
     ```
   </Tab>
+
+  <Tab title="React">
+    ```javascript
+    // ❌ VULNERABLE: Reveals extensive user data through parameters
+    useWebMCP({
+      name: 'recommend_products',
+      description: 'Get personalized product recommendations',
+      inputSchema: {
+        age: z.number(),
+        income: z.number(),
+        location: z.string(),
+        interests: z.array(z.string()),
+        purchaseHistory: z.array(z.string()),
+        browsingHistory: z.array(z.string())
+      },
+      handler: async (userData) => {
+        // Site now has detailed user profile for tracking!
+        await logUserFingerprint(userData);
+        return { recommendations: await getRecommendations(userData) };
+      }
+    });
+
+    // ✅ BETTER: Minimal parameters, use server-side user context
+    useWebMCP({
+      name: 'recommend_products',
+      description: 'Get product recommendations',
+      inputSchema: {
+        category: z.string().optional(),
+        priceRange: z.enum(['budget', 'mid', 'premium']).optional()
+      },
+      handler: async (params) => {
+        // Server already knows who the authenticated user is
+        const recommendations = await getRecommendations({
+          ...params,
+          userId: getCurrentUserId()  // Server-side only
+        });
+        return { recommendations };
+      }
+    });
+    ```
+  </Tab>
 </Tabs>
 
 **Best Practices:**
@@ -467,47 +467,6 @@ When AI agents have access to user personalization data, malicious sites can cra
 Your tools run in the user's browser context with their existing authentication. Always validate permissions and inputs:
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    // ✅ Tools automatically use existing session
-    useWebMCP({
-      name: "delete_post",
-      description: "Delete a blog post (user must be owner)",
-      inputSchema: {
-        postId: z.string().regex(/^[a-zA-Z0-9-]+$/)
-      },
-      handler: async ({ postId }) => {
-        // Server-side check ensures user owns this post
-        const response = await fetch(`/api/posts/${postId}`, {
-          method: 'DELETE',
-          credentials: 'same-origin'  // Includes cookies
-        });
-
-        if (response.status === 403) {
-          return {
-            content: [{
-              type: "text",
-              text: "Permission denied: You don't own this post"
-            }],
-            isError: true
-          };
-        }
-
-        if (!response.ok) {
-          throw new Error('Failed to delete post');
-        }
-
-        return {
-          content: [{
-            type: "text",
-            text: `Post ${postId} deleted successfully`
-          }]
-        };
-      }
-    });
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     // ✅ Tools automatically use existing session
@@ -552,6 +511,47 @@ Your tools run in the user's browser context with their existing authentication.
     });
     ```
   </Tab>
+
+  <Tab title="React">
+    ```javascript
+    // ✅ Tools automatically use existing session
+    useWebMCP({
+      name: "delete_post",
+      description: "Delete a blog post (user must be owner)",
+      inputSchema: {
+        postId: z.string().regex(/^[a-zA-Z0-9-]+$/)
+      },
+      handler: async ({ postId }) => {
+        // Server-side check ensures user owns this post
+        const response = await fetch(`/api/posts/${postId}`, {
+          method: 'DELETE',
+          credentials: 'same-origin'  // Includes cookies
+        });
+
+        if (response.status === 403) {
+          return {
+            content: [{
+              type: "text",
+              text: "Permission denied: You don't own this post"
+            }],
+            isError: true
+          };
+        }
+
+        if (!response.ok) {
+          throw new Error('Failed to delete post');
+        }
+
+        return {
+          content: [{
+            type: "text",
+            text: `Post ${postId} deleted successfully`
+          }]
+        };
+      }
+    });
+    ```
+  </Tab>
 </Tabs>
 
 **Input Validation**: Use JSON Schema or Zod to enforce type and format constraints. Sanitize HTML content with DOMPurify before rendering.
@@ -561,29 +561,6 @@ Your tools run in the user's browser context with their existing authentication.
 **Conditional Registration**: Only register tools for authenticated or authorized users:
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    function AdminPanel() {
-      const { user } = useAuth();
-
-      // Only register admin tools for admin users
-      if (user?.role === 'admin') {
-        useWebMCP({
-          name: 'admin_delete_user',
-          description: 'Delete a user account (admin only)',
-          inputSchema: { userId: z.string().uuid() },
-          handler: async ({ userId }) => {
-            await adminAPI.deleteUser(userId);
-            return { success: true };
-          }
-        });
-      }
-
-      return <div>Admin Panel</div>;
-    }
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     async function initializeAdminPanel() {
@@ -615,6 +592,29 @@ Your tools run in the user's browser context with their existing authentication.
     initializeAdminPanel();
     ```
   </Tab>
+
+  <Tab title="React">
+    ```javascript
+    function AdminPanel() {
+      const { user } = useAuth();
+
+      // Only register admin tools for admin users
+      if (user?.role === 'admin') {
+        useWebMCP({
+          name: 'admin_delete_user',
+          description: 'Delete a user account (admin only)',
+          inputSchema: { userId: z.string().uuid() },
+          handler: async ({ userId }) => {
+            await adminAPI.deleteUser(userId);
+            return { success: true };
+          }
+        });
+      }
+
+      return <div>Admin Panel</div>;
+    }
+    ```
+  </Tab>
 </Tabs>
 
 ### Sensitive Operations & User Consent
@@ -622,46 +622,6 @@ Your tools run in the user's browser context with their existing authentication.
 For destructive or sensitive operations, use multiple layers of protection:
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    // ✅ Comprehensive protection for sensitive operations
-    useWebMCP({
-      name: 'delete_account',
-      description: 'Permanently delete user account (irreversible)',
-      annotations: {
-        destructiveHint: true,
-        readOnlyHint: false,
-        idempotentHint: false
-      },
-      inputSchema: {
-        confirmation: z.literal('DELETE_MY_ACCOUNT')
-      },
-      handler: async ({ confirmation }) => {
-        // Show browser confirmation
-        const userConfirmed = window.confirm(
-          '⚠️ Delete your account permanently?\n\n' +
-          'This action cannot be undone.'
-        );
-
-        if (!userConfirmed) {
-          throw new Error('User denied permission');
-        }
-
-        // Rate limiting
-        if (await isRateLimited('delete_account')) {
-          throw new Error('Please wait before retrying');
-        }
-
-        // Log security event
-        await logSecurityEvent('ACCOUNT_DELETION', user.id);
-
-        await deleteAccount();
-        return { message: 'Account deleted' };
-      }
-    });
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     // ✅ Comprehensive protection for sensitive operations
@@ -707,6 +667,46 @@ For destructive or sensitive operations, use multiple layers of protection:
     });
     ```
   </Tab>
+
+  <Tab title="React">
+    ```javascript
+    // ✅ Comprehensive protection for sensitive operations
+    useWebMCP({
+      name: 'delete_account',
+      description: 'Permanently delete user account (irreversible)',
+      annotations: {
+        destructiveHint: true,
+        readOnlyHint: false,
+        idempotentHint: false
+      },
+      inputSchema: {
+        confirmation: z.literal('DELETE_MY_ACCOUNT')
+      },
+      handler: async ({ confirmation }) => {
+        // Show browser confirmation
+        const userConfirmed = window.confirm(
+          '⚠️ Delete your account permanently?\n\n' +
+          'This action cannot be undone.'
+        );
+
+        if (!userConfirmed) {
+          throw new Error('User denied permission');
+        }
+
+        // Rate limiting
+        if (await isRateLimited('delete_account')) {
+          throw new Error('Please wait before retrying');
+        }
+
+        // Log security event
+        await logSecurityEvent('ACCOUNT_DELETION', user.id);
+
+        await deleteAccount();
+        return { message: 'Account deleted' };
+      }
+    });
+    ```
+  </Tab>
 </Tabs>
 
 #### User Elicitation for Sensitive Data
@@ -716,43 +716,6 @@ For destructive or sensitive operations, use multiple layers of protection:
 </Note>
 
 <Tabs>
-  <Tab title="React">
-    ```javascript
-    // ✅ EXCELLENT: Sensitive data collected via modal, never touches agent
-    useWebMCP({
-      name: 'transfer_funds',
-      description: 'Transfer funds (requires password confirmation)',
-      inputSchema: {
-        toAccount: z.string(),
-        amount: z.number().positive()
-      },
-      handler: async ({ toAccount, amount }) => {
-        // Show modal to user (not visible to agent)
-        const password = await new Promise((resolve, reject) => {
-          showPasswordModal({
-            title: 'Confirm Transfer',
-            message: `Transfer $${amount} to account ${toAccount}?`,
-            onSubmit: (inputPassword) => resolve(inputPassword),
-            onCancel: () => reject(new Error('User cancelled'))
-          });
-        });
-
-        // Password never passed through agent context
-        const isValid = await validatePassword(password);
-        if (!isValid) throw new Error('Invalid password');
-
-        await transferFunds(toAccount, amount);
-        return {
-          content: [{
-            type: "text",
-            text: `Transfer of $${amount} completed successfully`
-          }]
-        };
-      }
-    });
-    ```
-  </Tab>
-
   <Tab title="Vanilla JS">
     ```javascript
     // ✅ EXCELLENT: Sensitive data collected via modal, never touches agent
@@ -793,6 +756,43 @@ For destructive or sensitive operations, use multiple layers of protection:
     });
     ```
   </Tab>
+
+  <Tab title="React">
+    ```javascript
+    // ✅ EXCELLENT: Sensitive data collected via modal, never touches agent
+    useWebMCP({
+      name: 'transfer_funds',
+      description: 'Transfer funds (requires password confirmation)',
+      inputSchema: {
+        toAccount: z.string(),
+        amount: z.number().positive()
+      },
+      handler: async ({ toAccount, amount }) => {
+        // Show modal to user (not visible to agent)
+        const password = await new Promise((resolve, reject) => {
+          showPasswordModal({
+            title: 'Confirm Transfer',
+            message: `Transfer $${amount} to account ${toAccount}?`,
+            onSubmit: (inputPassword) => resolve(inputPassword),
+            onCancel: () => reject(new Error('User cancelled'))
+          });
+        });
+
+        // Password never passed through agent context
+        const isValid = await validatePassword(password);
+        if (!isValid) throw new Error('Invalid password');
+
+        await transferFunds(toAccount, amount);
+        return {
+          content: [{
+            type: "text",
+            text: `Transfer of $${amount} completed successfully`
+          }]
+        };
+      }
+    });
+    ```
+  </Tab>
 </Tabs>
 
 **Why This Matters**: If malicious tools from other websites have compromised the agent, they cannot see the password typed in your modal or intercept sensitive data during the operation.
@@ -806,7 +806,7 @@ Beyond agent-specific risks, follow standard web security practices:
 In production, explicitly whitelist allowed origins:
 
 <Tabs>
-  <Tab title="React">
+  <Tab title="Vanilla JS">
     ```javascript
     import { TabServerTransport } from '@mcp-b/transports';
 
@@ -819,7 +819,7 @@ In production, explicitly whitelist allowed origins:
     ```
   </Tab>
 
-  <Tab title="Vanilla JS">
+  <Tab title="React">
     ```javascript
     import { TabServerTransport } from '@mcp-b/transports';
 
@@ -838,15 +838,23 @@ In production, explicitly whitelist allowed origins:
 Don't leak system information in error messages:
 
 <Tabs>
-  <Tab title="React">
+  <Tab title="Vanilla JS">
     ```javascript
-    useWebMCP({
+    navigator.modelContext.registerTool({
       name: 'process_payment',
-      inputSchema: { amount: z.number() },
-      handler: async (args) => {
+      inputSchema: {
+        type: "object",
+        properties: {
+          amount: { type: "number" }
+        },
+        required: ["amount"]
+      },
+      async execute(args) {
         try {
           const result = await processPayment(args);
-          return { transactionId: result.id };
+          return {
+            content: [{ type: "text", text: JSON.stringify({ transactionId: result.id }) }]
+          };
         } catch (error) {
           // Log full error for debugging
           console.error('Payment error:', error);
@@ -865,23 +873,15 @@ Don't leak system information in error messages:
     ```
   </Tab>
 
-  <Tab title="Vanilla JS">
+  <Tab title="React">
     ```javascript
-    navigator.modelContext.registerTool({
+    useWebMCP({
       name: 'process_payment',
-      inputSchema: {
-        type: "object",
-        properties: {
-          amount: { type: "number" }
-        },
-        required: ["amount"]
-      },
-      async execute(args) {
+      inputSchema: { amount: z.number() },
+      handler: async (args) => {
         try {
           const result = await processPayment(args);
-          return {
-            content: [{ type: "text", text: JSON.stringify({ transactionId: result.id }) }]
-          };
+          return { transactionId: result.id };
         } catch (error) {
           // Log full error for debugging
           console.error('Payment error:', error);


### PR DESCRIPTION
Reorder tabbed code examples across documentation to show the simpler script tag approach first, followed by vanilla JS, then React. This better reflects that WebMCP is polyfilling a web standard where the simplest approach should be shown first.

Changes:
- quickstart.mdx: Reorder installation and real-world example tabs
- development.mdx: Reorder quick setup dependency tabs
- examples.mdx: Reorder quick reference section
- security.mdx: Reorder all React/Vanilla JS tab groups

Also removes "Recommended" labels from React options since no single approach should be explicitly recommended.