### PR TITLE
fix: debounce nav logo MutationObserver to fix SPA navigation

### DIFF
--- a/inject-nav-logo-label.js
+++ b/inject-nav-logo-label.js
@@ -62,9 +62,10 @@
   }
 
   // Also observe for dynamic changes (e.g., SPA navigation or hydration)
-  const observer = new MutationObserver((mutations) => {
-    // If we already added labels, don't keep re-inserting them; function checks existing labels
-    insertLabel();
+  let debounceTimer;
+  const observer = new MutationObserver(() => {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(insertLabel, 200);
   });
 
   observer.observe(document.documentElement || document.body, { childList: true, subtree: true });


### PR DESCRIPTION
The MutationObserver in inject-nav-logo-label.js was firing insertLabel() on every DOM mutation, interfering with Mintlify's SPA router during tab navigation. Adds a 200ms debounce so navigation completes before the label script runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)