### PR TITLE
style: reformat architecture SVG

### DIFF
--- a/logo/mcp-b-architecture-dark.svg
+++ b/logo/mcp-b-architecture-dark.svg
@@ -1,1 +1,123 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420"><defs><linearGradient id="f" x1="16%" x2="78%" y1="12%" y2="88%"><stop offset="0%" stop-color="#2563eb" stop-opacity=".18"/><stop offset="54%" stop-color="#1d4ed8" stop-opacity=".08"/><stop offset="100%" stop-color="#0b1220" stop-opacity=".02"/></linearGradient><linearGradient id="g" x1="22%" x2="82%" y1="16%" y2="88%"><stop offset="0%" stop-color="#a855f7" stop-opacity=".18"/><stop offset="56%" stop-color="#7e22ce" stop-opacity=".08"/><stop offset="100%" stop-color="#140b1d" stop-opacity=".02"/></linearGradient><linearGradient id="h" x1="22%" x2="80%" y1="10%" y2="92%"><stop offset="0%" stop-color="#6366f1" stop-opacity=".66"/><stop offset="58%" stop-color="#4f46e5" stop-opacity=".3"/><stop offset="100%" stop-color="#312e81" stop-opacity=".12"/></linearGradient><linearGradient id="r" x1="0%" x2="0%" y1="0%" y2="100%"><stop offset="0%" stop-color="#223045"/><stop offset="100%" stop-color="#101827"/></linearGradient><linearGradient id="s" x1="0%" x2="100%" y1="0%" y2="100%"><stop offset="0%" stop-color="#6366f1"/><stop offset="100%" stop-color="#4338ca"/></linearGradient><linearGradient id="n" x1="0%" x2="100%" y1="0%" y2="0%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0"/><stop offset="100%" stop-color="#60a5fa" stop-opacity=".44"/></linearGradient><linearGradient id="o" x1="0%" x2="100%" y1="0%" y2="0%"><stop offset="0%" stop-color="#c084fc" stop-opacity=".44"/><stop offset="100%" stop-color="#c084fc" stop-opacity="0"/></linearGradient><linearGradient id="p" x1="0%" x2="100%" y1="0%" y2="0%"><stop offset="0%" stop-color="#818cf8" stop-opacity="0"/><stop offset="50%" stop-color="#a5b4fc" stop-opacity=".58"/><stop offset="100%" stop-color="#818cf8" stop-opacity="0"/></linearGradient><radialGradient id="c" cx="50%" cy="46%" r="48%"><stop offset="0%" stop-color="#4f46e5" stop-opacity=".28"/><stop offset="42%" stop-color="#312e81" stop-opacity=".18"/><stop offset="100%" stop-color="#08060d" stop-opacity="0"/></radialGradient><radialGradient id="a" cx="24%" cy="24%" r="34%"><stop offset="0%" stop-color="#1d4ed8" stop-opacity=".16"/><stop offset="100%" stop-color="#08060d" stop-opacity="0"/></radialGradient><radialGradient id="b" cx="78%" cy="24%" r="34%"><stop offset="0%" stop-color="#7e22ce" stop-opacity=".15"/><stop offset="100%" stop-color="#08060d" stop-opacity="0"/></radialGradient><filter id="e" width="140%" height="140%" x="-20%" y="-20%"><feDropShadow dx="0" dy="12" flood-color="#020617" flood-opacity=".24" stdDeviation="14"/></filter><filter id="q" width="140%" height="140%" x="-20%" y="-20%"><feDropShadow dx="0" dy="8" flood-color="#020617" flood-opacity=".24" stdDeviation="10"/></filter><filter id="j" width="180%" height="180%" x="-40%" y="-40%"><feDropShadow dx="0" dy="0" flood-color="#6366f1" flood-opacity=".24" stdDeviation="14"/><feDropShadow dx="0" dy="0" flood-color="#2563eb" flood-opacity=".1" stdDeviation="28"/></filter><clipPath id="i"><circle cx="280" cy="220" r="170"/></clipPath><pattern id="d" width="40" height="40" patternUnits="userSpaceOnUse"><path fill="none" stroke="rgba(255,255,255,0.045)" stroke-width=".5" d="M40 0H0v40"/></pattern></defs><rect width="100%" height="100%" fill="url(#a)" rx="12"/><rect width="100%" height="100%" fill="url(#b)" rx="12"/><rect width="100%" height="100%" fill="url(#c)" rx="12"/><rect width="100%" height="100%" fill="url(#d)" rx="12"/><g fill="none" stroke-opacity=".08" opacity=".92"><circle cx="280" cy="220" r="178" stroke="#60a5fa" stroke-width="12"/><circle cx="520" cy="220" r="178" stroke="#c084fc" stroke-width="12"/></g><g filter="url(#e)"><circle cx="280" cy="220" r="170" fill="url(#f)"/><circle cx="520" cy="220" r="170" fill="url(#g)"/><circle cx="520" cy="220" r="170" fill="url(#h)" clip-path="url(#i)" filter="url(#j)"/></g><path fill="none" stroke="url(#n)" stroke-linecap="round" stroke-width="1.2" d="M265 221h-53"/><path fill="none" stroke="url(#o)" stroke-linecap="round" stroke-width="1.2" d="M535 221h53"/><path fill="none" stroke="url(#p)" stroke-linecap="round" stroke-width="1.2" d="M356 239h88"/><circle cx="212" cy="221" r="3.5" fill="#60a5fa" fill-opacity=".56"/><circle cx="588" cy="221" r="3.5" fill="#c084fc" fill-opacity=".56"/><circle cx="400" cy="239" r="3.5" fill="#a5b4fc" fill-opacity=".58"/><text x="160" y="165" fill="#60a5fa" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="800" text-anchor="middle">WebMCP</text><text x="160" y="190" fill="#94a3b8" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" letter-spacing="1" text-anchor="middle">BROWSER PROPOSAL</text><g filter="url(#q)"><rect width="210" height="34" x="55" y="205" fill="url(#r)" stroke="rgba(96,165,250,0.18)" rx="8"/><path fill="none" stroke="#fff" stroke-opacity=".07" d="M61 212c31-6 75-6 198 0"/><text x="160" y="227" fill="#dbeafe" font-family="ui-monospace, &quot;SFMono-Regular&quot;, monospace" font-size="12" text-anchor="middle">navigator.modelContext</text></g><text x="160" y="268" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">Tool exposure</text><text x="160" y="288" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">for websites</text><text x="640" y="165" fill="#c084fc" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="800" text-anchor="middle">MCP</text><text x="640" y="190" fill="#94a3b8" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" letter-spacing="1" text-anchor="middle">SEPARATE PROTOCOL</text><g filter="url(#q)"><rect width="180" height="34" x="550" y="205" fill="url(#r)" stroke="rgba(192,132,252,0.18)" rx="8"/><path fill="none" stroke="#fff" stroke-opacity=".07" d="M556 212c24-6 66-6 168 0"/><text x="640" y="227" fill="#f5d0fe" font-family="ui-monospace, &quot;SFMono-Regular&quot;, monospace" font-size="12" text-anchor="middle">JSON-RPC Ecosystem</text></g><text x="640" y="268" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">Tools, prompts,</text><text x="640" y="288" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">and resources</text><text x="400" y="162" fill="#fff" font-family="system-ui, -apple-system, sans-serif" font-size="33" font-weight="900" text-anchor="middle">MCP-B</text><text x="400" y="188" fill="#e0e7ff" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" letter-spacing="1" text-anchor="middle">RUNTIME INTERSECTION</text><g filter="url(#q)"><rect width="210" height="36" x="295" y="205" fill="url(#s)" stroke="rgba(165,180,252,0.36)" rx="9"/><path fill="none" stroke="#fff" stroke-opacity=".12" stroke-width="1.1" d="M302 212c28-6 78-7 196 0"/><text x="400" y="228" fill="#fff" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="650" text-anchor="middle">Transport, Tooling &amp; Ext.</text></g><text x="400" y="268" fill="#c7d2fe" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" text-anchor="middle">Browser API shape</text><text x="400" y="288" fill="#c7d2fe" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" text-anchor="middle">+ MCP capabilities</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420">
+  <defs>
+    <linearGradient id="f" x1="16%" x2="78%" y1="12%" y2="88%">
+      <stop offset="0%" stop-color="#2563eb" stop-opacity=".18" />
+      <stop offset="54%" stop-color="#1d4ed8" stop-opacity=".08" />
+      <stop offset="100%" stop-color="#0b1220" stop-opacity=".02" />
+    </linearGradient>
+    <linearGradient id="g" x1="22%" x2="82%" y1="16%" y2="88%">
+      <stop offset="0%" stop-color="#a855f7" stop-opacity=".18" />
+      <stop offset="56%" stop-color="#7e22ce" stop-opacity=".08" />
+      <stop offset="100%" stop-color="#140b1d" stop-opacity=".02" />
+    </linearGradient>
+    <linearGradient id="h" x1="22%" x2="80%" y1="10%" y2="92%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity=".66" />
+      <stop offset="58%" stop-color="#4f46e5" stop-opacity=".3" />
+      <stop offset="100%" stop-color="#312e81" stop-opacity=".12" />
+    </linearGradient>
+    <linearGradient id="r" x1="0%" x2="0%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#2b415d" />
+      <stop offset="100%" stop-color="#162335" />
+    </linearGradient>
+    <linearGradient id="s" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#4338ca" />
+    </linearGradient>
+    <linearGradient id="n" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0" />
+      <stop offset="100%" stop-color="#60a5fa" stop-opacity=".44" />
+    </linearGradient>
+    <linearGradient id="o" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#c084fc" stop-opacity=".44" />
+      <stop offset="100%" stop-color="#c084fc" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="p" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#818cf8" stop-opacity="0" />
+      <stop offset="50%" stop-color="#a5b4fc" stop-opacity=".58" />
+      <stop offset="100%" stop-color="#818cf8" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="c" cx="50%" cy="46%" r="48%">
+      <stop offset="0%" stop-color="#4f46e5" stop-opacity=".28" />
+      <stop offset="42%" stop-color="#312e81" stop-opacity=".18" />
+      <stop offset="100%" stop-color="#08060d" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="a" cx="24%" cy="24%" r="34%">
+      <stop offset="0%" stop-color="#1d4ed8" stop-opacity=".16" />
+      <stop offset="100%" stop-color="#08060d" stop-opacity="0" />
+    </radialGradient>
+    <radialGradient id="b" cx="78%" cy="24%" r="34%">
+      <stop offset="0%" stop-color="#7e22ce" stop-opacity=".15" />
+      <stop offset="100%" stop-color="#08060d" stop-opacity="0" />
+    </radialGradient>
+    <filter id="e" width="140%" height="140%" x="-20%" y="-20%">
+      <feDropShadow dx="0" dy="12" flood-color="#020617" flood-opacity=".24" stdDeviation="14" />
+    </filter>
+    <filter id="q" width="140%" height="140%" x="-20%" y="-20%">
+      <feDropShadow dx="0" dy="8" flood-color="#020617" flood-opacity=".24" stdDeviation="10" />
+    </filter>
+    <filter id="j" width="180%" height="180%" x="-40%" y="-40%">
+      <feDropShadow dx="0" dy="0" flood-color="#6366f1" flood-opacity=".24" stdDeviation="14" />
+      <feDropShadow dx="0" dy="0" flood-color="#2563eb" flood-opacity=".1" stdDeviation="28" />
+    </filter>
+    <clipPath id="i">
+      <circle cx="280" cy="220" r="170" />
+    </clipPath>
+    <pattern id="d" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path fill="none" stroke="rgba(255,255,255,0.045)" stroke-width=".5" d="M40 0H0v40" />
+    </pattern>
+  </defs>
+
+  <rect width="100%" height="100%" fill="url(#a)" rx="12" />
+  <rect width="100%" height="100%" fill="url(#b)" rx="12" />
+  <rect width="100%" height="100%" fill="url(#c)" rx="12" />
+  <rect width="100%" height="100%" fill="url(#d)" rx="12" />
+
+  <g fill="none" stroke-opacity=".08" opacity=".92">
+    <circle cx="280" cy="220" r="178" stroke="#60a5fa" stroke-width="12" />
+    <circle cx="520" cy="220" r="178" stroke="#c084fc" stroke-width="12" />
+  </g>
+
+  <g filter="url(#e)">
+    <circle cx="280" cy="220" r="170" fill="url(#f)" />
+    <circle cx="520" cy="220" r="170" fill="url(#g)" />
+    <circle cx="520" cy="220" r="170" fill="url(#h)" clip-path="url(#i)" filter="url(#j)" />
+  </g>
+
+  <path fill="none" stroke="url(#n)" stroke-linecap="round" stroke-width="1.2" d="M265 221h-53" />
+  <path fill="none" stroke="url(#o)" stroke-linecap="round" stroke-width="1.2" d="M535 221h53" />
+  <path fill="none" stroke="url(#p)" stroke-linecap="round" stroke-width="1.2" d="M356 239h88" />
+
+  <circle cx="212" cy="221" r="3.5" fill="#60a5fa" fill-opacity=".56" />
+  <circle cx="588" cy="221" r="3.5" fill="#c084fc" fill-opacity=".56" />
+  <circle cx="400" cy="239" r="3.5" fill="#a5b4fc" fill-opacity=".58" />
+
+  <text x="160" y="165" fill="#60a5fa" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="800" text-anchor="middle">WebMCP</text>
+  <text x="160" y="190" fill="#94a3b8" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" letter-spacing="1" text-anchor="middle">BROWSER PROPOSAL</text>
+  <g filter="url(#q)">
+    <rect width="210" height="34" x="55" y="205" fill="url(#r)" stroke="rgba(96,165,250,0.34)" rx="8" />
+    <path fill="none" stroke="#fff" stroke-opacity=".14" d="M61 212c31-6 75-6 198 0" />
+    <text x="160" y="227" fill="#dbeafe" font-family="ui-monospace, &quot;SFMono-Regular&quot;, monospace" font-size="12" text-anchor="middle">navigator.modelContext</text>
+  </g>
+  <text x="160" y="268" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">Tool exposure</text>
+  <text x="160" y="288" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">for websites</text>
+
+  <text x="640" y="165" fill="#c084fc" font-family="system-ui, -apple-system, sans-serif" font-size="28" font-weight="800" text-anchor="middle">MCP</text>
+  <text x="640" y="190" fill="#94a3b8" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" letter-spacing="1" text-anchor="middle">SEPARATE PROTOCOL</text>
+  <g filter="url(#q)">
+    <rect width="180" height="34" x="550" y="205" fill="url(#r)" stroke="rgba(192,132,252,0.34)" rx="8" />
+    <path fill="none" stroke="#fff" stroke-opacity=".14" d="M556 212c24-6 66-6 168 0" />
+    <text x="640" y="227" fill="#f5d0fe" font-family="ui-monospace, &quot;SFMono-Regular&quot;, monospace" font-size="12" text-anchor="middle">JSON-RPC Ecosystem</text>
+  </g>
+  <text x="640" y="268" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">Tools, prompts,</text>
+  <text x="640" y="288" fill="#64748b" font-family="system-ui, -apple-system, sans-serif" font-size="13" text-anchor="middle">and resources</text>
+
+  <text x="400" y="162" fill="#fff" font-family="system-ui, -apple-system, sans-serif" font-size="33" font-weight="900" text-anchor="middle">MCP-B</text>
+  <text x="400" y="188" fill="#e0e7ff" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600" letter-spacing="1" text-anchor="middle">RUNTIME INTERSECTION</text>
+  <g filter="url(#q)">
+    <rect width="210" height="36" x="295" y="205" fill="url(#s)" stroke="rgba(165,180,252,0.5)" rx="9" />
+    <path fill="none" stroke="#fff" stroke-opacity=".2" stroke-width="1.1" d="M302 212c28-6 78-7 196 0" />
+    <text x="400" y="228" fill="#fff" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="650" text-anchor="middle">Transport, Tooling &amp; Ext.</text>
+  </g>
+  <text x="400" y="268" fill="#c7d2fe" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" text-anchor="middle">Browser API shape</text>
+  <text x="400" y="288" fill="#c7d2fe" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="500" text-anchor="middle">+ MCP capabilities</text>
+</svg>


### PR DESCRIPTION
Reformats the dark architecture SVG from minified to pretty-printed for readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)